### PR TITLE
Bridge between client and MQTT connection

### DIFF
--- a/src/cotonic.broker.js
+++ b/src/cotonic.broker.js
@@ -287,18 +287,19 @@ var cotonic = cotonic || {};
         if (typeof topics == "string") {
             topics = [ topics ];
         }
-        unsubscribe_subscriber({type: "page", tag: options.tag}, { topics: topics });
+        unsubscribe_subscriber({type: "page", wid: options.wid}, { topics: topics });
     }
 
     function unsubscribe_subscriber(sub, msg) {
         let bridge_topics = {};
         let acks = [];
 
-        for (let i = 0; i < msg.topics; i++) {
+        for (let i = 0; i < msg.topics.length; i++) {
             remove(msg.topics[i], sub);
             acks.push(0);
 
             // Collect bridge topics per bridge
+            const mqtt_topic = cotonic.mqtt.remove_named_wildcards(msg.topics[i]);
             let m = mqtt_topic.match(/^bridge\/([^\/]+)\/.*/);
             if (m !== null && m[1] != "+") {
                 if (bridge_topics[ m[1] ] === undefined) {

--- a/src/cotonic.broker.js
+++ b/src/cotonic.broker.js
@@ -25,7 +25,7 @@ var cotonic = cotonic || {};
     /* Trie implementation */
     const CHILDREN = 0;
     const VALUE = 1;
-    
+
     function new_node(value) { return [null, value]; }
 
     function flush() {
@@ -36,185 +36,326 @@ var cotonic = cotonic || {};
     flush();
 
     function add(topic, thing) {
-	const path = topic.split("/");
-	
-	let i = 0;
-	let current = root;
-	
-	for(i = 0; i < path.length; i++) {
-	    let children = current[CHILDREN];
-	    if(children === null) {
-		children = current[CHILDREN] = {};
-	    }
-	    
-	    if(!children.hasOwnProperty(path[i])) {
-		children[path[i]] = new_node(null);
-	    }
-	    
-	    current = children[path[i]];
-	}
+        const path = topic.split("/");
 
-	let v = current[VALUE];
-	if(v === null) {
-	    v = current[VALUE] = [];
-	}
-	
-	v.push(thing);
+        let i = 0;
+        let current = root;
+
+        for(i = 0; i < path.length; i++) {
+            let children = current[CHILDREN];
+            if(children === null) {
+                children = current[CHILDREN] = {};
+            }
+
+            if(!children.hasOwnProperty(path[i])) {
+                children[path[i]] = new_node(null);
+            }
+
+            current = children[path[i]];
+        }
+
+        let v = current[VALUE];
+        if(v === null) {
+            v = current[VALUE] = [];
+        }
+
+        let index = indexOfSubscription(v, thing);
+        if(index > -1) {
+            v.splice(index, 1);
+        }
+        v.push(thing);
     }
 
     function match(topic) {
-	const path = topic.split("/");
-	let matches = [];
+        const path = topic.split("/");
+        let matches = [];
 
-	collect_matches(path, root, matches);
+        collect_matches(path, root, matches);
 
-	return matches;
+        return matches;
     }
 
     function collect_matches(path, trie, matches) {
         if(trie === undefined) return;
 
-	if(path.length === 0) {
-	    if(trie[VALUE] !== null) {
-		matches.push.apply(matches, trie[VALUE])
-		return;
-	    }
-	}
+        if(path.length === 0) {
+            if(trie[VALUE] !== null) {
+                matches.push.apply(matches, trie[VALUE])
+                return;
+            }
+        }
 
-	let children = trie[CHILDREN];
-	if(children === null) return;
+        let children = trie[CHILDREN];
+        if(children === null) return;
 
-	let sub_path = path.slice(1);
+        let sub_path = path.slice(1);
 
-	collect_matches(sub_path, children[path[0]], matches);
-	collect_matches(sub_path, children["+"], matches);
-	collect_matches([], children["#"], matches);
+        collect_matches(sub_path, children[path[0]], matches);
+        collect_matches(sub_path, children["+"], matches);
+        collect_matches([], children["#"], matches);
     }
 
     function remove(topic, thing) {
-	const path = topic.split("/");
-	let current = root;
-	let i = 0;
-	let visited = [current];
+        const path = topic.split("/");
+        let current = root;
+        let i = 0;
+        let visited = [current];
 
-	for(i = 0; i < path.length; i++) {
-	    let children = current[CHILDREN];
-	    if(children === null) {
-		return;
-	    }
-	    
-	    if(!children.hasOwnProperty(path[i])) {
-		return;
-	    }
+        for(i = 0; i < path.length; i++) {
+            let children = current[CHILDREN];
+            if(children === null) {
+                return;
+            }
 
-	    current = children[path[i]];
-	    visited.unshift(current);
-	}
+            if(!children.hasOwnProperty(path[i])) {
+                return;
+            }
 
-	/* Remove the node, and check for empty nodes along the path */
-	let v = current[VALUE];
-	let index = v.indexOf(thing);
-	if(index > -1) {
-	    v.splice(index, 1);
-	    
-	    if(v.length === 0) {
-		current[VALUE] = null;
-		path.reverse();
-		for(i = 0; i < visited.length - 1; i++) {
-		    let v = visited[i];
-	    
-		    if(v[CHILDREN] === null && v[VALUE] === null) {
-			let v1 = visited[i+1];
-			delete v1[CHILDREN][path[i]];
-			if(Object.keys(v1[CHILDREN]).length == 0) {
-			    v1[CHILDREN] = null;
-			}
-			continue;
-		    }
-		    return;
-		}
-	    }
-	}
+            current = children[path[i]];
+            visited.unshift(current);
+        }
+
+        /* Remove the node, and check for empty nodes along the path */
+        let v = current[VALUE];
+        let index = indexOfSubscription(v, thing);
+        if(index > -1) {
+            v.splice(index, 1);
+
+            if(v.length === 0) {
+                current[VALUE] = null;
+                path.reverse();
+                for(i = 0; i < visited.length - 1; i++) {
+                    let v = visited[i];
+
+                    if(v[CHILDREN] === null && v[VALUE] === null) {
+                        let v1 = visited[i+1];
+                        delete v1[CHILDREN][path[i]];
+                        if(Object.keys(v1[CHILDREN]).length == 0) {
+                            v1[CHILDREN] = null;
+                        }
+                        continue;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    function indexOfSubscription( v, thing ) {
+        let index = v.indexOf(thing);
+        if (index == -1) {
+            for(index = v.length-1; index >= 0; index--) {
+                let sub = v[index];
+                if (thing.type == sub.type && sub.wid && sub.wid === thing.wid) {
+                    return index;
+                }
+            }
+        }
+        return index;
     }
 
     /* ----- end trie ---- */
-    
+
     /* We assume every message is for the broker. */
     cotonic.receive(function(data, wid) {
-	if(!data.type) return;
+        if(!data.type) return;
 
-	switch(data.type) {
-	case "connect":
-	    return handle_connect(wid, data);
-	case "publish":
-	    return handle_publish(wid, data);
-	case "subscribe":
-	    return handle_subscribe(wid, data);
-	default:
-	    console.error("Received unknown command", data.type);
-	};
+        switch(data.type) {
+            case "connect":
+                return handle_connect(wid, data);
+            case "publish":
+                return handle_publish(wid, data);
+            case "subscribe":
+                return handle_subscribe(wid, data);
+            case "unsubscribe":
+                return handle_subscribe(wid, data);
+            case "pingreq":
+                return handle_pingreq(wid, data);
+            default:
+                console.error("Received unknown command", data);
+        };
     });
 
     function handle_connect(wid, data) {
-	// TODO: Start keep-alive timer
-	clients[wid] = data;
-	cotonic.send(wid, {type: "connack"});
+        // TODO: Start keep-alive timer for will handling if pingreq missing
+        if (data.client_id !== wid) {
+            console.error("Wrong client_id in connect from " + wid, data);
+        }
+        clients[wid] = data;
+        cotonic.send(wid, {type: "connack", reason_code: 0});
     }
 
     function handle_subscribe(wid, data) {
-        let subscription = {type: "worker", wid: wid};
+        let acks = subscribe_subscriber({type: "worker", wid: wid}, data);
+        cotonic.send(wid, {type: "suback", packet_id: data.packet_id, acks: acks});
+    }
 
-	add(data.topic, subscription);
-        cotonic.send(wid, {type: "suback", sub_id: data.id});
-
-        const retained = get_matching_retained(data.topic);
-        for(let i = 0; i < retained.length; i++) {
-            publish_message(subscription, retained[i].topic, retained[i].retained.message);
-        }
+    function handle_unsubscribe(wid, data) {
+        let acks = unsubscribe_subscriber({type: "worker", wid: wid}, data);
+        cotonic.send(wid, {type: "unsuback", packet_id: data.packet_id, acks: acks});
     }
 
     function handle_publish(wid, data) {
-	publish(data.topic, data.message, data.options);
+        publish_mqtt_message(data.topic, data);
     }
 
-    /** 
+    function handle_pingreq(wid, data) {
+        // TODO: reset keep-alive timer
+        cotonic.send(wid, {type: "pingresp"});
+    }
+
+    /**
      * Subscribe from main page
      */
-    function subscribe(topic, callback) {
-        const subscription = {type: "page", topic: topic, callback: callback};
-        const mqtt_topic = cotonic.mqtt.remove_named_wildcards(topic);
+    function subscribe(topics, callback, options) {
+        options = options || {};
+        let subtopics = [];
 
-	add(mqtt_topic, subscription); 
-
-        // TODO optimization possible. Only check all topics when the subscribe
-        // contains a wildcard.
-        const retained = get_matching_retained(mqtt_topic);
-        for(let i = 0; i < retained.length; i++) {
-            publish_message(subscription, retained[i].topic, retained[i].retained.message);
+        if (typeof topics == "string") {
+            topics = [ topics ];
         }
+
+        for (let k = 0; k < topics.length; k++) {
+            if (typeof topics[k] == "string") {
+                subtopics.push({
+                    topic: topics[k],
+                    qos: options.qos || 0,
+                    retain_handling: options.retain_handling || 0,
+                    retain_as_published: options.retain_as_published || false,
+                    no_local: options.no_local || false
+                });
+            } else {
+                subtopics.push(topics[k]);
+            }
+        }
+        const msg = {
+            type: "subscribe",
+            topics: subtopics,
+            properties: options.properties || {}
+        };
+        return subscribe_subscriber({type: "page", wid: options.wid, callback: callback}, msg);
+    }
+
+
+    function subscribe_subscriber(subscription, msg) {
+        let bridge_topics = {};
+        let acks = [];
+        for(let k = 0; k < msg.topics.length; k++) {
+            const t = msg.topics[k];
+            const mqtt_topic = cotonic.mqtt.remove_named_wildcards(t.topic);
+            subscription.sub = t;
+            subscription.topic = t.topic;
+
+            add(mqtt_topic, subscription);
+            acks.push(0);
+
+            if(t.retain_handling != 0) {
+                // TODO optimization possible. Only check all topics when the subscribe
+                // contains a wildcard.
+                const retained = get_matching_retained(mqtt_topic);
+                for(let i = 0; i < retained.length; i++) {
+                    publish_subscriber(subscription, retained[i].retained.message, subscription.wid);
+                }
+            }
+
+            // Collect bridge topics per bridge
+            let m = mqtt_topic.match(/^bridge\/([^\/]+)\/.*/);
+            if (m !== null && m[1] != "+") {
+                if (bridge_topics[ m[1] ] === undefined) {
+                    bridge_topics[ m[1] ] = [];
+                }
+                bridge_topics[ m[1] ].push(t);
+            }
+        }
+
+        // Relay bridge topics to the bridges
+        for(let b in bridge_topics) {
+            let sub = {
+                type: "subscribe",
+                topics: bridge_topics[b],
+                properties: msg.properties || {}
+            };
+            publish("$bridge/" + b + "/control", sub);
+        }
+        return acks;
+    }
+
+    /**
+      * Unsubscribe
+      */
+    function unsubscribe( topics, options ) {
+        if (typeof topics == "string") {
+            topics = [ topics ];
+        }
+        unsubscribe_subscriber({type: "page", tag: options.tag}, { topics: topics });
+    }
+
+    function unsubscribe_subscriber(sub, msg) {
+        let bridge_topics = {};
+        let acks = [];
+
+        for (let i = 0; i < msg.topics; i++) {
+            remove(msg.topics[i], sub);
+            acks.push(0);
+
+            // Collect bridge topics per bridge
+            let m = mqtt_topic.match(/^bridge\/([^\/]+)\/.*/);
+            if (m !== null && m[1] != "+") {
+                if (bridge_topics[ m[1] ] === undefined) {
+                    bridge_topics[ m[1] ] = [];
+                }
+                bridge_topics[ m[1] ].push(t);
+            }
+        }
+
+        // Relay bridge topics to the bridges
+        for(let b in bridge_topics) {
+            let unsub = {
+                type: "unsubscribe",
+                topics: bridge_topics[b],
+                properties: msg.properties || {}
+            };
+            publish("$bridge/" + b + "/control", unsub);
+        }
+        return acks;
     }
 
     /**
      * Publish from main page
      */
-    function publish(topic, message, options) {
-	const subscriptions = match(topic);
-
-        if(options && options.retained) {
-            retain(topic, message, options);
-        }
-
-	for(let i = 0; i < subscriptions.length; i++) {
-            publish_message(subscriptions[i], topic, message);
-	}
+    function publish(topic, payload, options) {
+        options = options || {};
+        let msg = {
+            type: "publish",
+            topic: topic,
+            payload: payload,
+            qos: options.qos || 0,
+            retain: options.retain || false,
+            properties: options.properties || {}
+        };
+        publish_mqtt_message(msg, options);
     }
 
-    function publish_message(sub, topic, payload) {
+    function publish_mqtt_message(msg, options) {
+        const subscriptions = match(msg.topic);
+        if(msg.retain) {
+            retain(msg);
+        }
+
+        for(let i = 0; i < subscriptions.length; i++) {
+            publish_subscriber(subscriptions[i], msg, options.wid);
+        }
+    }
+
+    function publish_subscriber(sub, mqttmsg, wid) {
+        if (sub.wid && sub.wid === wid && sub.sub.no_local) {
+            return;
+        }
+
         if(sub.type === "worker") {
-            cotonic.send(sub.wid, {type: "publish", topic: topic, payload: payload})
+            cotonic.send(sub.wid, mqttmsg)
         } else if(sub.type === "page") {
-            const p = cotonic.mqtt.extract(sub.topic, topic);
-            sub.callback(payload, p);
+            sub.callback(mqttmsg, cotonic.mqtt.extract(sub.topic, mqttmsg.topic));
         } else {
             console.error("Unkown subscription type", sub);
         }
@@ -224,13 +365,12 @@ var cotonic = cotonic || {};
         return "c_retained$" + topic;
     }
 
-    function retain(topic, message, options) {
-        const key = retain_key(topic);
-        
-        if(message) {
+    function retain(message) {
+        const key = retain_key(message.topic);
+
+        if(message.payload !== undefined && message.payload !== null && message.payload !== "") {
             sessionStorage.setItem(key, JSON.stringify({
-                message: message,
-                options: options
+                message: message
             }));
         } else {
             sessionStorage.removeItem(key);
@@ -240,7 +380,7 @@ var cotonic = cotonic || {};
     function get_matching_retained(topic) {
         const prefix = "c_retained$";
         let matching = [];
-        
+
         for(let i = 0; i < sessionStorage.length; i++) {
             let key = sessionStorage.key(i);
 
@@ -255,7 +395,7 @@ var cotonic = cotonic || {};
 
             const retained = get_retained(retained_topic);
             if(retained !== null)
-                matching.push({topic: topic, retained: retained}); 
+                matching.push({topic: topic, retained: retained});
         }
 
         return matching;
@@ -302,4 +442,8 @@ var cotonic = cotonic || {};
     cotonic.broker.match = match;
     cotonic.broker.publish = publish;
     cotonic.broker.subscribe = subscribe;
+    cotonic.broker.unsubscribe = unsubscribe;
+
+    // Bridge API for relaying publish messages
+    cotonic.broker.publish_mqtt_message = publish_mqtt_message;
 }(cotonic));

--- a/src/cotonic.broker.js
+++ b/src/cotonic.broker.js
@@ -249,7 +249,7 @@ var cotonic = cotonic || {};
             add(mqtt_topic, subscription);
             acks.push(0);
 
-            if(t.retain_handling != 0) {
+            if(t.retain_handling < 2) {
                 // TODO optimization possible. Only check all topics when the subscribe
                 // contains a wildcard.
                 const retained = get_matching_retained(mqtt_topic);
@@ -348,7 +348,7 @@ var cotonic = cotonic || {};
     }
 
     function publish_subscriber(sub, mqttmsg, wid) {
-        if (sub.wid && sub.wid === wid && sub.sub.no_local) {
+        if (wid && sub.wid && sub.wid === wid && sub.sub.no_local) {
             return;
         }
 

--- a/src/cotonic.broker.js
+++ b/src/cotonic.broker.js
@@ -294,12 +294,12 @@ var cotonic = cotonic || {};
     // For testing
     cotonic.broker._root = root;
     cotonic.broker._add = add;
-    cotonic.broker._match = match;
     cotonic.broker._remove = remove;
     cotonic.broker._flush = flush;
     cotonic.broker._delete_all_retained = delete_all_retained;
 
     // External API
+    cotonic.broker.match = match;
     cotonic.broker.publish = publish;
     cotonic.broker.subscribe = subscribe;
 }(cotonic));

--- a/src/cotonic.js
+++ b/src/cotonic.js
@@ -43,32 +43,32 @@ var cotonic = cotonic || {};
     }
 
     /**
-     * Handle incoming messages from workers 
+     * Handle incoming messages from workers
      */
     function message_from_worker(wid, msg) {
         var data = msg.data;
 
-	if(receive_handler) {
-	    receive_handler(data, wid);
-	} else {
-	    console.log("Unhandled message from worker", wid, msg);
-	}
+        if(receive_handler) {
+            receive_handler(data, wid);
+        } else {
+            console.log("Unhandled message from worker", wid, msg);
+        }
     }
 
     /**
      * Handle error from worker
      */
     function error_from_worker(wid, e) {
-	// TODO, actually handle the error
-	console.log("Error from worker", wid, e);
+        // TODO, actually handle the error
+        console.log("Error from worker", wid, e);
     }
 
     /**
      * Start a worker
      */
     function spawn(url, args) {
-	if(!BASE_WORKER_SRC)
-	    throw("Can't spawn worker, no data-base-worker-src attribute set.");
+        if(!BASE_WORKER_SRC)
+            throw("Can't spawn worker, no data-base-worker-src attribute set.");
 
         const blob = new Blob(["importScripts(\"", BASE_WORKER_SRC, "\");"]);
         const blobURL = window.URL.createObjectURL(blob);
@@ -82,7 +82,7 @@ var cotonic = cotonic || {};
             wid: worker_id}]);
 
         worker.onmessage = message_from_worker.bind(this, worker_id);
-	worker.onerror = error_from_worker.bind(this, worker_id);
+        worker.onerror = error_from_worker.bind(this, worker_id);
 
         workers[worker_id] = worker;
 
@@ -94,7 +94,7 @@ var cotonic = cotonic || {};
      */
     function send(wid, message) {
         if(wid === 0) {
-	    setTimeout(function() { handler(message, wid) }, 0);
+            setTimeout(function() { handler(message, wid) }, 0);
             return;
         }
 
@@ -105,10 +105,10 @@ var cotonic = cotonic || {};
     }
 
     function receive(handler) {
-	receive_handler = handler;
+        receive_handler = handler;
     }
 
-    cotonic.set_worker_base_src = set_worker_base_src; 
+    cotonic.set_worker_base_src = set_worker_base_src;
 
     cotonic.spawn = spawn;
     cotonic.send = send;

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -19,7 +19,90 @@ var cotonic = cotonic || {};
 
 (function (cotonic) {
 
+    // Bridges to remote servers and clients
+    var bridges = {};
+
+    var newBridge = function( remote ) {
+        remote = remote || 'origin';
+        if (sessions[ remote ]) {
+            return bridges[remote];
+        } else {
+            var bridge = new mqttBridge();
+            bridges[remote] = bridge;
+            bridge.connect(remote);
+            return bridge;
+        }
+    };
+
+    var findBridge = function( remote ) {
+        remote = remote || 'origin';
+        return bridges[remote];
+    };
+
+
+    /*************************************************************************************************/
+    /****************************************** MQTT Bridge ******************************************/
+    /*************************************************************************************************/
+
+    function mqttBridge () {
+
+        var remote;
+        var session;
+        var self = this;
+        var clientId;
+        var routingId;
+
+        // TODO: pass authentication details to the session
+        this.connect = function ( remote ) {
+            self.remote = remote;
+            // 1. Start a mqtt_session for the remote
+            self.session = cotonic.mqtt_session.newSession(remote, self);
+        }
+
+        this.match = function ( topicId ) {
+            return self.clientId === topicId || self.routingId === topicId;
+        }
+
+        this.auth = function ( /* ... */ ) {
+            // Start a re-authentication, useful when logging on
+            // TODO: decide if we need to restart the session with a new clientId (could be an option)
+        }
+
+        this.sessionConnack = function ( clientId, connack ) {
+            // 1. Register the clientId and the optional 'cotonic-routing-id' property
+            // 2. Check 'session_present' flag
+            //    - If not present then:
+            //      1. Add subscription on server for "bridge/<clientId>/#"
+            //      2. Add subscription on server for "bridge/<routingId>/#"
+            //      3. Resubscribe client subscriptions (fetch all local subscriptions matching 'bridge/<remote>/#')
+            // Publish to '$bridge/<remote>/status' topic that we connected (retained)
+            // Subscribers then handle the 'session_present' flag.
+        }
+
+        this.sessionAuth = function ( ConnectOrAuth, isConnected ) {
+            // Either:
+            // - Add authentication credentials to the CONNECT packet
+            // - Received an AUTH packet, perform extended (re-)authentication
+        }
+
+        this.sessionDisconnect = function ( optDisconnect ) {
+            // Publish to '$bridge/<remote>/status' topic that this remote disconnected (retained)
+        }
+
+    }
+
+
+    function init() {
+        // 1. Subscribe to 'bridge/#'
+        // 2. Add a mqtt router hook for subscriptions to 'bridge/#'
+        // 3. ?? Start a bridge to 'origin'
+    }
+
+    init();
+
+    // Publish the MQTT bridge functions.
     cotonic.mqtt_bridge = cotonic.mqtt_bridge || {};
-    // cotonic.mqtt_bridge.newSession = newSession;
+    cotonic.mqtt_bridge.newBridge = newBridge;
+    cotonic.mqtt_bridge.findBridge = findBridge;
 
 }(cotonic));

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
+// TODO: subscribe on the remote routing/client-id topics
+// TODO: strip remote routing/client-id topics before relaying to local tree
+// TODO: unsubscribe
+// TOOD: admin for de-duplication of subscriptions
+
 "use strict";
 var cotonic = cotonic || {};
 
 (function (cotonic) {
-    const LOCAL_TOPIC = "bridge/+remote/#topic";
-    const STATUS_TOPIC = "$bridge/+remote/status";
+    const BRIDGE_LOCAL_TOPIC = "bridge/+remote/#topic";
+    const BRIDGE_STATUS_TOPIC = "$bridge/+remote/status";
+    const BRIDGE_CONTROL_TOPIC = "$bridge/+remote/control";
+
+    const SESSION_IN_TOPIC = "session/+remote/in"
+    const SESSION_OUT_TOPIC = "session/+remote/out"
+    const SESSION_STATUS_TOPIC = "session/+remote/status"
+    const SESSION_CONTROL_TOPIC = "session/+remote/control"
 
     // Bridges to remote servers and clients
     var bridges = {};
@@ -28,15 +39,13 @@ var cotonic = cotonic || {};
         remote = remote || 'origin';
         mqtt_session = mqtt_session || cotonic.mqtt_session;
 
-        if (bridges[ remote ]) {
-            return bridges[remote];
-        } 
+        let bridge = bridges[remote];
 
-        let bridge = new mqttBridge();
-        bridges[remote] = bridge;
-
-        bridge.connect(remote, mqtt_session);
-         
+        if (!bridge) {
+            bridge = new mqttBridge();
+            bridges[remote] = bridge;
+            bridge.connect(remote, mqtt_session);
+        }
         return bridge;
     };
 
@@ -61,33 +70,159 @@ var cotonic = cotonic || {};
         var session;
         var clientId;
         var routingId;
-        var statusTopic;
+        var local_topics = {};
+        var remote_subscriptions = {};
+        var sessionTopic;
         var self = this;
 
-
         // TODO: pass authentication details to the session
-        this.connect = function ( remote , mqtt_session ) {
+        this.connect = function ( remote, mqtt_session ) {
             self.remote = remote;
-            statusTopic = cotonic.mqtt.fill(STATUS_TOPIC, {remote: remote});
+            self.local_topics = {
+                // Comm between system and bridge
+                bridge_status: cotonic.mqtt.fill(BRIDGE_STATUS_TOPIC, {remote: remote}),
+                bridge_local: cotonic.mqtt.fill(BRIDGE_LOCAL_TOPIC, {remote: remote, topic: "#topic"}),
+                bridge_control: cotonic.mqtt.fill(BRIDGE_CONTROL_TOPIC, {remote: remote, topic: "#topic"}),
 
-            // 1. Start a mqtt_session for the remote
-            self.session = mqtt_session.newSession(remote, self);
+                // Comm between session and bridge
+                session_in: cotonic.mqtt.fill(SESSION_IN_TOPIC, {remote: remote}),
+                session_out: cotonic.mqtt.fill(SESSION_OUT_TOPIC, {remote: remote}),
+                session_status: cotonic.mqtt.fill(SESSION_STATUS_TOPIC, {remote: remote}),
+                session_control: cotonic.mqtt.fill(SESSION_CONTROL_TOPIC, {remote: remote})
+            };
+            let wid = "bridge/" + remote;
+            cotonic.broker.subscribe(self.local_topics.bridge_local, relayOut, {wid: wid, no_local: true});
+            cotonic.broker.subscribe(self.local_topics.bridge_control, bridgeControl);
+            cotonic.broker.subscribe(self.local_topics.session_in, relayIn);
+            cotonic.broker.subscribe(self.local_topics.session_status, sessionStatus);
+
+            // 3. Start a mqtt_session WebWorker for the remote
+            self.session = mqtt_session.newSession(remote, self.local_topics);
             publishStatus( false );
-
         };
+
+
+        // Relay a publish message to the remote
+        function relayOut ( msg, props ) {
+            console.log("handleBridgeLocal", msg, props)
+            switch (msg.type) {
+                case 'publish':
+                    // - remove "bridge/+remote/" from the topic
+                    // - rewrite response_topic (prefix "bridge/+routingid/")
+                    // - publish to local_topics.session_out
+                    msg.topic = dropRoutingTopic(msg.topic);
+                    if (msg.properties && msg.properties.response_topic) {
+                        msg.properties.response_topic = remoteRoutingTopic(msg.properties.response_topic);
+                    }
+                    cotonic.broker.publish(self.local_topics.session_out, msg);
+                    break;
+                default:
+                    console.log("Bridge relayOut received unknown message", msg);
+                    break;
+            }
+        }
+
+        // Handle a message from the session, maybe relay to the local broker
+        function relayIn ( msg ) {
+            let relay = msg.payload;
+            switch (relay.type) {
+                case 'publish':
+                    // TODO: handle publish to the routing and client-id topics
+                    //       these prefixes must be removed (but not other prefixes)
+                    // relay.topic = localRoutingTopic(relay.topic);
+                    if (relay.properties && relay.properties.response_topic) {
+                        relay.properties.response_topic = remoteRoutingTopic(relay.properties.response_topic);
+                    }
+                    cotonic.broker.publish_mqtt_message(relay);
+                    break;
+                case 'connack':
+                    sessionConnack(relay);
+                    break;
+                case 'disconnect':
+                    break;
+                case 'auth':
+                    // auth (re-authenticate)
+                    break;
+                case 'suback':
+                    // suback (per topic)
+                    // non-conformant: add the topic in the ack
+                    // discuss: should this be a publish with payload?
+                    break;
+                case 'puback':
+                case 'pubrec':
+                    // puback (per topic)
+                    // non-conformant: add the topic in the ack
+                    // discuss: should this be a publish with payload?
+                    break;
+                case 'publish':
+                    // status in payload
+                    break;
+                default:
+                    console.log("Bridge relayIn received unknown message", msg);
+                    break;
+            }
+        }
+
+        // Bridge control, called by broker on subscribe and unsubscribe
+        function bridgeControl ( msg ) {
+            let payload = msg.payload;
+            switch (payload.type) {
+                case 'subscribe':
+                    // Fetch topics
+                    // Remove "bridge/+/" from topic
+                    for(let k = 0; k < payload.topics.length; k++) {
+                        payload.topics[k].topic = dropRoutingTopic(payload.topics[k].topic);
+                    }
+                    // Check administration:
+                    //  - drop if qos <= or retain_handling >=
+                    //  - subscribe if new or qos > or retain_handling <
+                    // Relay subscribe with new topic list
+                    cotonic.broker.publish(self.local_topics.session_out, payload);
+                    break;
+                case 'unsubscribe':
+                    // Fetch topics
+                    // For all topics: check if subscriber exists on broker
+                    // If no subscriber: add to unsub list
+                    // If subscriber: remove from unsub list
+                    // Remove "bridge/+/" from topic
+                    // Relay unsubscribe with new topic list
+                    break;
+                default:
+                    console.log("Bridge bridgeControl received unknown message", msg);
+                    break;
+            }
+        }
+
+        // Session status changes
+        function sessionStatus ( msg ) {
+            console.log("sessionStatus", msg);
+        }
+
+        function remoteRoutingTopic ( topic ) {
+            return "bridge/" + self.routingId + "/" + topic;
+        }
+
+        function localRoutingTopic ( topic ) {
+            return "bridge/" + self.remote + "/" + topic;
+        }
+
+        function dropRoutingTopic ( topic ) {
+            return topic.replace(/^bridge\/[^\/]+\//, '');
+        }
+
 
         this.match = function ( topicId ) {
             return self.clientId === topicId || self.routingId === topicId;
         };
 
-        this.auth = function ( /* ... */ ) {
-            // Start a re-authentication, useful when logging on
-            // TODO: decide if we need to restart the session with a new clientId (could be an option)
-        };
-
-        this.sessionConnack = function ( clientId, connack ) {
+        function sessionConnack ( msg ) {
             // 1. Register the clientId and the optional 'cotonic-routing-id' property
-            self.clientId = clientId;
+            self.clientId = msg.client_id;
+            if (msg.properties && msg.properties['cotonic-routing-id']) {
+                self.routingId = msg.properties['cotonic-routing-id']
+            } else {
+                self.routingId = msg.client_id;
+            }
 
             // 2. Check 'session_present' flag
             //    - If not present then:
@@ -96,12 +231,6 @@ var cotonic = cotonic || {};
             //      3. Resubscribe client subscriptions (fetch all local subscriptions matching 'bridge/<remote>/#')
             // Publish to '$bridge/<remote>/status' topic that we connected (retained)
             // Subscribers then handle the 'session_present' flag.
-
-            // Subscribe to the local topic
-            cotonic.broker.subscribe(cotonic.mqtt.fill(LOCAL_TOPIC, {remote: remote, topic: "#topic"}), function(m, p) {
-                console.log(m, p);
-                // Relay code here
-            });
 
             publishStatus( true );
         };
@@ -117,18 +246,18 @@ var cotonic = cotonic || {};
             publishStatus( false );
         };
 
-    }
 
-    function publishStatus( session_present ) {
-        cotonic.broker.publish(statusTopic, {
-            session_present: session_present
-        }, {retained: true});
+        function publishStatus( session_present ) {
+            cotonic.broker.publish(
+                self.local_topics.bridge_status,
+                { session_present: session_present },
+                { retained: true });
+        }
     }
 
     function init() {
         // 1. Subscribe to 'bridge/#'
         // 2. Add a mqtt router hook for subscriptions to 'bridge/#'
-        // 3. ?? Start a bridge to 'origin'
     }
 
     init();

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -18,6 +18,7 @@
 var cotonic = cotonic || {};
 
 (function (cotonic) {
+    const LOCAL_TOPIC = "bridge/+remote/#topic";
 
     // Bridges to remote servers and clients
     var bridges = {};
@@ -34,6 +35,13 @@ var cotonic = cotonic || {};
         bridges[remote] = bridge;
 
         bridge.connect(remote, mqtt_session);
+
+        // Subscribe to the local topic
+        cotonic.broker.subscribe(cotonic.mqtt.fill(LOCAL_TOPIC, {remote: remote, topic: "#topic"}), function(m, p) {
+            console.log(m, p);
+            // Relay code here
+        })
+         
         return bridge;
     };
 

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -24,7 +24,7 @@ var cotonic = cotonic || {};
 
     var newBridge = function( remote ) {
         remote = remote || 'origin';
-        if (sessions[ remote ]) {
+        if (bridges[ remote ]) {
             return bridges[remote];
         } else {
             var bridge = new mqttBridge();

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -22,21 +22,29 @@ var cotonic = cotonic || {};
     // Bridges to remote servers and clients
     var bridges = {};
 
-    var newBridge = function( remote ) {
+    var newBridge = function( remote, mqtt_session ) {
         remote = remote || 'origin';
+        mqtt_session = mqtt_session || cotonic.mqtt_session
+
         if (bridges[ remote ]) {
             return bridges[remote];
-        } else {
-            var bridge = new mqttBridge();
-            bridges[remote] = bridge;
-            bridge.connect(remote);
-            return bridge;
-        }
+        } 
+
+        let bridge = new mqttBridge();
+        bridges[remote] = bridge;
+
+        bridge.connect(remote, mqtt_session);
+        return bridge;
     };
 
     var findBridge = function( remote ) {
         remote = remote || 'origin';
         return bridges[remote];
+    };
+
+    var deleteBridge = function( remote ) {
+        remote = remote || 'origin';
+        delete bridges[remote];
     };
 
 
@@ -53,10 +61,10 @@ var cotonic = cotonic || {};
         var routingId;
 
         // TODO: pass authentication details to the session
-        this.connect = function ( remote ) {
+        this.connect = function ( remote , mqtt_session ) {
             self.remote = remote;
             // 1. Start a mqtt_session for the remote
-            self.session = cotonic.mqtt_session.newSession(remote, self);
+            self.session = mqtt_session.newSession(remote, self);
         }
 
         this.match = function ( topicId ) {
@@ -104,5 +112,6 @@ var cotonic = cotonic || {};
     cotonic.mqtt_bridge = cotonic.mqtt_bridge || {};
     cotonic.mqtt_bridge.newBridge = newBridge;
     cotonic.mqtt_bridge.findBridge = findBridge;
+    cotonic.mqtt_bridge.deleteBridge = deleteBridge;
 
 }(cotonic));

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -140,7 +140,7 @@ var cotonic = cotonic || {};
                         relay.topic = localRoutingTopic(relay.topic);
                     }
                     if (relay.properties && relay.properties.response_topic) {
-                        relay.properties.response_topic = remoteRoutingTopic(relay.properties.response_topic);
+                        relay.properties.response_topic = localRoutingTopic(relay.properties.response_topic);
                     }
                     cotonic.broker.publish_mqtt_message(relay, { wid: self.wid });
                     break;

--- a/src/cotonic.mqtt_packet.js
+++ b/src/cotonic.mqtt_packet.js
@@ -46,7 +46,7 @@ var cotonic = cotonic || {};
         payload_format_indicator:   [ 0x01, "bool", false ],
         message_expiry_interval:    [ 0x02, "uint32", false ],
         content_type:               [ 0x03, "utf8", false ],
-        response_topic:             [ 0x08, "topic", false ],
+        response_topic:             [ 0x08, "utf8", false ],
         correlation_data:           [ 0x09, "bin", false ],
         subscription_identifier:    [ 0x0B, "varint", true ],
         session_expiry_interval:    [ 0x11, "uint32", false ],

--- a/src/cotonic.mqtt_transport.ws.js
+++ b/src/cotonic.mqtt_transport.ws.js
@@ -257,8 +257,8 @@ var cotonic = cotonic || {};
             } else {
                 self.remoteUrl = 'wss:' + self.remoteHost + WS_CONTROLLER_PATH;
             }
-            setTimeout(connect, WS_CONNECT_DELAY );
-            setInterval(periodic, WS_PERIODIC_DELAY );
+            setTimeout(connect, WS_CONNECT_DELAY);
+            setInterval(periodic, WS_PERIODIC_DELAY);
         }
 
         init();

--- a/src/cotonic.mqtt_transport.ws.js
+++ b/src/cotonic.mqtt_transport.ws.js
@@ -151,7 +151,7 @@ var cotonic = cotonic || {};
                 return false;
             }
             if (isStateForceClosed()) {
-                return fals;e
+                return false
             }
             self.data = new Uint8Array(0);
             self.isConnected = false;

--- a/src/cotonic.worker.js
+++ b/src/cotonic.worker.js
@@ -78,7 +78,7 @@ var cotonic = cotonic || {};
                 let new_topics = [];
                 let sub_id = model.sub_id++;
 
-                for (k = 0; k < data.topics.length; k++) {
+                for (let k = 0; k < data.topics.length; k++) {
                     let t = data.topics[k];
                     let mqtt_topic = cotonic.mqtt.remove_named_wildcards(t.topic);
 
@@ -121,16 +121,18 @@ var cotonic = cotonic || {};
                     delete model.pending_acks[data.packet_id];
 
                     for(let k = 0; k < pending.topics.length; k++) {
-                        let subreq = pending.topics[k];
+                        let subreq = pending.subs[k];
                         let mqtt_topic = subreq.topic;
                         if(model.subscriptions[mqtt_topic] === undefined) {
                             model.subscriptions[mqtt_topic] = [];
                         }
 
                         if(data.acks[k] < 0x80) {
-                            subs.push({topic: data.topics[k],
-                                       sub: subreq,
-                                       callback: pending.callback});
+                            model.subscriptions[mqtt_topic].push({
+                                topic: pending.topics[k],
+                                sub: subreq,
+                                callback: pending.callback
+                            });
                         }
                         if(pending.ack_callback) {
                             setTimeout(pending.ack_callback, 0, topic, data.acks[k], subreq);
@@ -332,7 +334,7 @@ var cotonic = cotonic || {};
         if (typeof(topics) == "string") {
             ts = [
                 {
-                    topic: topic,
+                    topic: topics,
                     qos: 0,
                     retain_handling: 0,
                     retain_as_published: false,

--- a/src/cotonic.worker.js
+++ b/src/cotonic.worker.js
@@ -23,14 +23,14 @@ var cotonic = cotonic || {};
 (function(self) {
 
     let model = {
-        id: undefined,
+        client_id: undefined,
 
         connected: false,
         connecting: false,
 
         sub_id: 0,
         subscriptions: {}, // topic -> [callback]
-        pending_subscriptions: {}, // sub-id -> callback
+        pending_acks: {}, // sub-id -> callback
 
         selfClose: self.close
     }
@@ -38,88 +38,177 @@ var cotonic = cotonic || {};
     model.present = function(data) {
         /* State changes happen here */
         if(state.connected(model)) {
-	    // PUBLISH
-	    if(data.type == "publish") {
-		if(data.from == "client") {
-		    self.postMessage({type: data.type, topic: data.topic, message: data.message, options: data.options});
-		} else {
-		    // Lookup matching topics, and trigger callbacks
-		    for(let pattern in model.subscriptions) {
-                        if(!cotonic.mqtt.matches(pattern, data.topic))
-                            continue;
+            // PUBLISH
+            if(data.type == "publish") {
+                if(data.from == "client") {
+                    // publish to broker
+                    let options = data.options || {};
+                    let msg = {
+                        type: "publish",
+                        topic: data.topic,
+                        payload: data.payload,
+                        qos: options.qos || 0,
+                        retain: options.retain || false,
+                        properties: options.properties || {}
+                    }
+                    self.postMessage(msg);
+                } else {
+                    // Receive publish from broker, call matching subscription callbacks
+                    for(let pattern in model.subscriptions) {
+                        if(cotonic.mqtt.matches(pattern, data.topic)) {
+                            let subs = model.subscriptions[pattern];
+                            for(let i=0; i < subs.length; i++) {
+                                let subscription = subs[i];
+                                try {
+                                    subscription.callback(data,
+                                                          cotonic.mqtt.extract(
+                                                              subscription.topic, data.topic));
+                                } catch(e) {
+                                    console.error("Error during callback of: " + pattern, e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-			let subs = model.subscriptions[pattern];
-			for(let i=0; i < subs.length; i++) {
-                            let subscription = subs[i];
-	                    try {
-				subscription.callback(data.msg,
-                                                      cotonic.mqtt.extract(
-                                                          subscription.topic, data.topic));
-			    } catch(e) {
-				console.error("Error during callback of: " + pattern, e);
-			    }
-			}
-		    }
-		}
-	    }
-
-	    // SUBSCRIBE
+            // SUBSCRIBE
             if(data.type == "subscribe" && data.from == "client") {
+                let new_subs = [];
+                let new_topics = [];
                 let sub_id = model.sub_id++;
-                let sub_topic = data.topic;
-                let already_subscribed = false;
-		let mqtt_topic = cotonic.mqtt.remove_named_wildcards(data.topic);
 
-                // Check if there already is a subscription with the same topic.
-		for(let pattern in model.subscriptions) {
-                    if(pattern != mqtt_topic) continue;
+                for (k = 0; k < data.topics.length; k++) {
+                    let t = data.topics[k];
+                    let mqtt_topic = cotonic.mqtt.remove_named_wildcards(t.topic);
 
-                    already_subscribed = true;
-                    
-                    let subs = model.subscriptions[pattern];
-                    subs.push({topic: sub_topic, callback: data.callback})
-                    if(data.suback_callback) {
-                        setTimeout(data.suback_callback, 0);
+                    // Check if there is a subscription with the same MQTT topic.
+                    if (model.subscriptions[mqtt_topic]) {
+                        // TODO: check qos / retain_handling
+                        //       if qos > or retain_handling < then resubscribe
+                        already_subscribed = true;
+
+                        let subs = model.subscriptions[mqtt_topic];
+                        subs.push({topic: t.topic, callback: data.callback})
+                        if(data.ack_callback) {
+                            setTimeout(data.ack_callback, 0);
+                        }
+                    } else {
+                        let newsub = {
+                            topic: mqtt_topic,
+                            qos: t.qos || 0,
+                            retain_handling: t.retain_handling || 0,
+                            retain_as_published: t.retain_as_published || false,
+                            no_local: t.no_local || false
+                        };
+                        new_subs.push(newsub);
+                        new_topics.push(t.topic);
                     }
                 }
 
-                if(!already_subscribed) {
-                    self.postMessage({type: "subscribe", topic: mqtt_topic, id: sub_id});
-                    data.mqtt_topic = mqtt_topic;
-                    model.pending_subscriptions[sub_id] = data;
+                if(new_topics.length > 0) {
+                    self.postMessage({type: "subscribe", topics: new_subs, packet_id: sub_id});
+                    data.subs = new_subs;
+                    data.topics = new_topics;
+                    model.pending_acks[sub_id] = data;
                 }
             }
 
-	    // SUBACK
+            // SUBACK
             if(data.type == "suback" && data.from == "broker") {
-                let pending_subscription = model.pending_subscriptions[data.sub_id];
-                if(pending_subscription) {
-                    delete model.pending_subscriptions[data.sub_id];
+                let pending = model.pending_acks[data.packet_id];
+                if(pending) {
+                    delete model.pending_acks[data.packet_id];
 
-                    let subs = model.subscriptions[pending_subscription.mqtt_topic];
-		    if(subs == undefined) {
-                        subs = model.subscriptions[pending_subscription.mqtt_topic] = [];
-		    }
+                    for(let k = 0; k < pending.topics.length; k++) {
+                        let subreq = pending.topics[k];
+                        let mqtt_topic = subreq.topic;
+                        if(model.subscriptions[mqtt_topic] === undefined) {
+                            model.subscriptions[mqtt_topic] = [];
+                        }
 
-		    subs.push({topic: pending_subscription.topic,
-                               callback: pending_subscription.callback});
-
-                    if(pending_subscription.suback_callback) {
-                        setTimeout(pending_subscription.suback_callback, 0);
-                        delete pending_subscription.suback_callback;
+                        if(data.acks[k] < 0x80) {
+                            subs.push({topic: data.topics[k],
+                                       sub: subreq,
+                                       callback: pending.callback});
+                        }
+                        if(pending.ack_callback) {
+                            setTimeout(pending.ack_callback, 0, topic, data.acks[k], subreq);
+                        }
+                    }
+                    if(pending.ack_callback) {
+                        delete pending.ack_callback;
                     }
                 }
             }
+
+            // UNSUBSCRIBE
+            // TODO: use a subscriber tag to know which subscription is canceled
+            //       now we unsubscribe all subscribers
+            if(data.type == "unsubscribe" && data.from == "client") {
+                let sub_id = model.sub_id++;
+                let mqtt_topics = [];
+                for (k = 0; k < data.topics.length; k++) {
+                    let t = data.topics[k];
+                    let mqtt_topic = cotonic.mqtt.remove_named_wildcards(t);
+                    mqtt_topics.push(mqtt_topic);
+                }
+                self.postMessage({type: "unsubscribe", topics: mqtt_topics, packet_id: sub_id});
+                data.mqtt_topics = mqtt_topics;
+                model.pending_acks[sub_id] = data;
+            }
+
+            // UNSUBACK
+            if(data.type == "unsuback" && data.from == "broker") {
+                let pending = model.pending_acks[data.packet_id];
+                if(pending) {
+                    delete model.pending_acks[data.packet_id];
+
+                    for(let i = 0; i < pending.mqtt_topics; i++) {
+                        let mqtt_topic = pending.mqtt_topics[i];
+                        if (data.acks[i] < 0x80) {
+                            delete model.subscriptions[mqtt_topic];
+                        }
+
+                        if(pending.ack_callback) {
+                            setTimeout(pending.ack_callback, 0, mqtt_topic, data.acks[k]);
+                        }
+                    }
+                    if(pending.ack_callback) {
+                        delete pending.ack_callback;
+                    }
+                }
+            }
+
+            // PING
+            if(data.type == "pingreq" && data.from == "client") {
+                // TODO: if broker doesn't answer then stop this worker
+                self.postMessage({type: "pingreq"});
+            }
+
+            if(data.type == "pingresp" && data.from == "broker") {
+                // TODO: Connection and broker are alive, we can stay alive
+            }
+
         } else if(state.disconnected(model)) {
             if(data.type == "connect") {
-                model.id = data.id;
+                model.client_id = data.id;
                 model.connected = false;
                 model.connecting = true;
-                self.postMessage({type: "connect", willTopic: data.willTopic, willMessage: data.willMessage})
-            } else if(data.type == "publish") {
+                self.postMessage({
+                    type: "connect",
+                    client_id: data.id,
+                    will_topic: data.will_topic,
+                    will_payload: data.will_payload
+                });
+            } else {
+                // message before connect, queue?
+                console.error("Message during diconnect state", data);
             }
         } else if(state.connecting(model)) {
             if(data.type == "connack" && data.from == "broker") {
+                // assume reason_code == 0
+                // register assigned client identifier?
                 model.connecting = false;
                 model.connected = true;
                 if(self.on_connect) {
@@ -186,14 +275,14 @@ var cotonic = cotonic || {};
     let actions = {};
 
     function client_cmd(type, data, present) {
-	present = present || model.present;
-	data.from = "client";
-	data.type = type;
+        present = present || model.present;
+        data.from = "client";
+        data.type = type;
         present(data);
     }
 
     actions.on_message = function(e) {
-	let data = e.data;
+        let data = e.data;
         if(data.type) {
             data.from = "broker";
             model.present(e.data);
@@ -206,7 +295,9 @@ var cotonic = cotonic || {};
     actions.disconnect = client_cmd.bind(null, "disconnect");
     actions.connect = client_cmd.bind(null, "connect");
     actions.subscribe = client_cmd.bind(null, "subscribe");
+    actions.unsubscribe = client_cmd.bind(null, "unsubscribe");
     actions.publish = client_cmd.bind(null, "publish");
+    actions.pingreq = client_cmd.bind(null, "pingreq");
 
     actions.connect_timeout = function(data, present) {
         present = present || model.present;
@@ -227,16 +318,51 @@ var cotonic = cotonic || {};
         actions.close();
     }
 
-    self.connect = function(id, willTopic, willMessage) {
-        actions.connect({id: id, willTopic: willTopic, willMessage: willMessage});
+    self.connect = function(id, willTopic, willPayload) {
+        actions.connect({
+            client_id: id,
+            will_topic: willTopic,
+            will_payload: willPayload
+        });
     }
 
-    self.subscribe = function(topic, callback, suback_callback) {
-        actions.subscribe({topic: topic, callback: callback, suback_callback: suback_callback});
+    self.subscribe = function(topics, callback, ack_callback) {
+        let ts;
+
+        if (typeof(topics) == "string") {
+            ts = [
+                {
+                    topic: topic,
+                    qos: 0,
+                    retain_handling: 0,
+                    retain_as_published: false,
+                    no_local: false
+                }
+            ];
+        } else {
+            // Assume array with topic subscriptions
+            ts = topics;
+        }
+        actions.subscribe({topics: ts, callback: callback, ack_callback: ack_callback});
     }
 
-    self.publish = function(topic, message, options) {
-	actions.publish({topic, topic, message: message, options: options});
+    self.unsubscribe = function(topics, callback, ack_callback) {
+        let ts;
+
+        if (typeof(topics) == "string") {
+            ts = [ topics ];
+        } else {
+            ts = topics;
+        }
+        actions.unsubscribe({topics: ts, callback: callback, ack_callback: ack_callback});
+    }
+
+    self.publish = function(topic, payload, options) {
+        actions.publish({topic: topic, payload: payload, options: options});
+    }
+
+    self.pingreq = function() {
+        actions.pingreq();
     }
 
     self.disconnect = function() {

--- a/test/all.html
+++ b/test/all.html
@@ -16,6 +16,8 @@
                     "cotonic.ui.html",
                     "cotonic.mqtt.html",
                     "cotonic.mqtt_packet.html",
+                    "cotonic.mqtt_transport.html",
+                    "cotonic.mqtt_bridge.html",
                     "cotonic.broker.html",
                     "cotonic.worker.html"
                 ];

--- a/test/cotonic.broker.test.js
+++ b/test/cotonic.broker.test.js
@@ -26,20 +26,20 @@ QUnit.test("Subscribe and publish, with wildcards", function(assert) {
     cotonic.broker.publish("foo/bar", "Hello nobody!");
 
     cotonic.broker.subscribe("foo/#", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
     
     cotonic.broker.subscribe("bar/+", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
 
     cotonic.broker.publish("foo/bar", "One");
     cotonic.broker.publish("foo/bar/baz", "Two");
     cotonic.broker.publish("bar/this", "Three");
 
-    assert.deepEqual([{msg: "One", prop: {}},
-                      {msg: "Two", prop: {}},
-                      {msg: "Three", prop: {}}], publishes, "Three matches");
+    assert.deepEqual([{payload: "One", prop: {}},
+                      {payload: "Two", prop: {}},
+                      {payload: "Three", prop: {}}], publishes, "Three matches");
 
     cotonic.broker._flush();
 });
@@ -50,20 +50,20 @@ QUnit.test("Subscribe and publish, with named wildcards", function(assert) {
     cotonic.broker.publish("foo/bar", "Hello nobody!");
 
     cotonic.broker.subscribe("foo/#a", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
     
     cotonic.broker.subscribe("bar/+a", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
 
     cotonic.broker.publish("foo/bar", "One");
     cotonic.broker.publish("foo/bar/baz", "Two");
     cotonic.broker.publish("bar/this", "Three");
 
-    assert.deepEqual([{msg: "One", prop: {a: ["bar"]}},
-                      {msg: "Two", prop: {a: ["bar", "baz"]}},
-                      {msg: "Three", prop: {a: "this"}}], publishes, "Three matches");
+    assert.deepEqual([{payload: "One", prop: {a: ["bar"]}},
+                      {payload: "Two", prop: {a: ["bar", "baz"]}},
+                      {payload: "Three", prop: {a: "this"}}], publishes, "Three matches");
 
     cotonic.broker._flush();
 });
@@ -76,13 +76,13 @@ QUnit.test("Subscribe and publish, retained messages", function(assert) {
     cotonic.broker.publish("retained/bar", "Hello I'm retained!", {retained: true});
 
     cotonic.broker.subscribe("retained/#a", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
 
     assert.equal(1, publishes.length, "There is one message");
 
     cotonic.broker.subscribe("#a", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
 
     assert.equal(2, publishes.length, "There are two messages");
@@ -97,7 +97,7 @@ QUnit.test("Delete retained messages", function(assert) {
     cotonic.broker.publish("retained/bar", "", {retained: true});
 
     cotonic.broker.subscribe("retained/#a", function(message, prop) {
-	publishes.push({msg: message, prop: prop});
+	publishes.push({payload: message, prop: prop});
     });
     
     assert.equal(0, publishes.length, "There are no messages");

--- a/test/cotonic.broker.test.js
+++ b/test/cotonic.broker.test.js
@@ -79,13 +79,13 @@ QUnit.test("Subscribe and publish, retained messages", function(assert) {
         publishes.push({payload: message.payload, prop: prop});
     });
 
-    assert.equal(1, publishes.length, "There is one message");
+    assert.equal(publishes.length, 1, "There is one message");
 
     cotonic.broker.subscribe("#a", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
 
-    assert.equal(2, publishes.length, "There are two messages");
+    assert.equal(publishes.length, 2, "There are two messages");
     cotonic.broker._delete_all_retained();
 });
 

--- a/test/cotonic.broker.test.js
+++ b/test/cotonic.broker.test.js
@@ -10,7 +10,7 @@ QUnit.test("Subscribe and publish, no wildcards", function(assert) {
     cotonic.broker.publish("a/b/c", "Hello nobody!");
     
     cotonic.broker.subscribe("a/b/c", function(message, prop) {
-	publishes.push(message);
+        publishes.push(message.payload);
     });
 
     cotonic.broker.publish("a/b/c", "Hello world!");
@@ -26,11 +26,11 @@ QUnit.test("Subscribe and publish, with wildcards", function(assert) {
     cotonic.broker.publish("foo/bar", "Hello nobody!");
 
     cotonic.broker.subscribe("foo/#", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
     
     cotonic.broker.subscribe("bar/+", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
 
     cotonic.broker.publish("foo/bar", "One");
@@ -50,11 +50,11 @@ QUnit.test("Subscribe and publish, with named wildcards", function(assert) {
     cotonic.broker.publish("foo/bar", "Hello nobody!");
 
     cotonic.broker.subscribe("foo/#a", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
     
     cotonic.broker.subscribe("bar/+a", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
 
     cotonic.broker.publish("foo/bar", "One");
@@ -73,16 +73,16 @@ QUnit.test("Subscribe and publish, retained messages", function(assert) {
 
     cotonic.broker._delete_all_retained();
 
-    cotonic.broker.publish("retained/bar", "Hello I'm retained!", {retained: true});
+    cotonic.broker.publish("retained/bar", "Hello I'm retained!", {retain: true});
 
     cotonic.broker.subscribe("retained/#a", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
 
     assert.equal(1, publishes.length, "There is one message");
 
     cotonic.broker.subscribe("#a", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
 
     assert.equal(2, publishes.length, "There are two messages");
@@ -93,11 +93,11 @@ QUnit.test("Delete retained messages", function(assert) {
     let publishes = [];
 
     cotonic.broker._delete_all_retained();
-    cotonic.broker.publish("retained/bar", "Hello I'm retained!", {retained: true});
-    cotonic.broker.publish("retained/bar", "", {retained: true});
+    cotonic.broker.publish("retained/bar", "Hello I'm retained!", {retain: true});
+    cotonic.broker.publish("retained/bar", "", {retain: true});
 
     cotonic.broker.subscribe("retained/#a", function(message, prop) {
-	publishes.push({payload: message, prop: prop});
+        publishes.push({payload: message.payload, prop: prop});
     });
     
     assert.equal(0, publishes.length, "There are no messages");

--- a/test/cotonic.broker.test.js
+++ b/test/cotonic.broker.test.js
@@ -8,7 +8,7 @@ QUnit.test("Subscribe and publish, no wildcards", function(assert) {
     let publishes = [];
 
     cotonic.broker.publish("a/b/c", "Hello nobody!");
-    
+
     cotonic.broker.subscribe("a/b/c", function(message, prop) {
         publishes.push(message.payload);
     });
@@ -28,7 +28,7 @@ QUnit.test("Subscribe and publish, with wildcards", function(assert) {
     cotonic.broker.subscribe("foo/#", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
-    
+
     cotonic.broker.subscribe("bar/+", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
@@ -52,7 +52,7 @@ QUnit.test("Subscribe and publish, with named wildcards", function(assert) {
     cotonic.broker.subscribe("foo/#a", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
-    
+
     cotonic.broker.subscribe("bar/+a", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
@@ -89,6 +89,29 @@ QUnit.test("Subscribe and publish, retained messages", function(assert) {
     cotonic.broker._delete_all_retained();
 });
 
+QUnit.test("Subscribe, publish, unsubscribe, publish", function(assert) {
+    let publishes = [];
+
+    cotonic.broker._delete_all_retained();
+
+    cotonic.broker.subscribe("plop", function(message, prop) {
+        publishes.push({payload: message.payload, prop: prop});
+    }, { wid: "x" });
+
+    cotonic.broker.publish("plop", "First");
+    cotonic.broker.unsubscribe("plop", { wid: "x" });
+    cotonic.broker.publish("plop", "Second");
+
+    assert.equal(publishes.length, 1, "There is one message");
+
+    assert.deepEqual([
+            {payload: "First", prop: {}}
+        ], publishes, "Single match");
+
+    cotonic.broker._flush();
+});
+
+
 QUnit.test("Delete retained messages", function(assert) {
     let publishes = [];
 
@@ -99,9 +122,8 @@ QUnit.test("Delete retained messages", function(assert) {
     cotonic.broker.subscribe("retained/#a", function(message, prop) {
         publishes.push({payload: message.payload, prop: prop});
     });
-    
+
     assert.equal(0, publishes.length, "There are no messages");
 
 })
 
-    

--- a/test/cotonic.mqtt_bridge.html
+++ b/test/cotonic.mqtt_bridge.html
@@ -4,10 +4,14 @@
         <link rel="stylesheet" href="lib/qunit.css">
         <script src="lib/qunit.js"></script>
 
+        <script type="text/javascript" src="../src/cotonic.js"></script>
+        <script type="text/javascript" src="../src/cotonic.mqtt.js"></script>
         <script type="text/javascript" src="../src/cotonic.mqtt_packet.js"></script>
 
         <script type="text/javascript" src="../src/cotonic.mqtt_session.js"></script>
         <script type="text/javascript" src="../src/cotonic.mqtt_transport.ws.js"></script>
+        <script type="text/javascript" src="../src/cotonic.broker.js"></script>
+
         <script type="text/javascript" src="../src/cotonic.mqtt_bridge.js"></script>
 
         <script type="text/javascript" src="cotonic.mqtt_bridge.test.js"></script>

--- a/test/cotonic.mqtt_bridge.html
+++ b/test/cotonic.mqtt_bridge.html
@@ -5,12 +5,12 @@
         <script src="lib/qunit.js"></script>
 
         <script type="text/javascript" src="../src/cotonic.mqtt_packet.js"></script>
-        <script type="text/javascript" src="../src/cotonic.mqtt_transport.ws.js"></script>
+        <script type="text/javascript" src="../src/cotonic.mqtt_bridge.js"></script>
 
-        <script type="text/javascript" src="cotonic.mqtt_transport.test.js"></script>
+        <script type="text/javascript" src="cotonic.mqtt_bridge.test.js"></script>
     </head>
     <body>
-        <h1>MQTT Transport test</h1>
+        <h1>MQTT Bridge Test</h1>
 
         <div id="qunit"></div>
     </body>

--- a/test/cotonic.mqtt_bridge.html
+++ b/test/cotonic.mqtt_bridge.html
@@ -5,6 +5,9 @@
         <script src="lib/qunit.js"></script>
 
         <script type="text/javascript" src="../src/cotonic.mqtt_packet.js"></script>
+
+        <script type="text/javascript" src="../src/cotonic.mqtt_session.js"></script>
+        <script type="text/javascript" src="../src/cotonic.mqtt_transport.ws.js"></script>
         <script type="text/javascript" src="../src/cotonic.mqtt_bridge.js"></script>
 
         <script type="text/javascript" src="cotonic.mqtt_bridge.test.js"></script>

--- a/test/cotonic.mqtt_bridge.test.js
+++ b/test/cotonic.mqtt_bridge.test.js
@@ -22,3 +22,12 @@ QUnit.test("Create default mqtt_bridge", function(assert) {
     mqtt_bridge.deleteBridge();
     assert.equal(mqtt_bridge.findBridge(), undefined, "Check if the bridge is deleted");
 });
+
+QUnit.test("Connect with mock mqtt_bridge", function(assert) {
+    const mqtt_bridge = cotonic.mqtt_bridge;
+
+    let bridge = mqtt_bridge.newBridge(undefined, {
+        newSession: function() { return }
+    });
+    assert.equal(!!bridge, true, "Check if bridge is created");
+})

--- a/test/cotonic.mqtt_bridge.test.js
+++ b/test/cotonic.mqtt_bridge.test.js
@@ -8,8 +8,17 @@ QUnit.test("cotonic.mqtt_bridge is defined", function(assert) {
     assert.equal(cotonic.hasOwnProperty('mqtt_bridge'), true, "Check if mqtt_bridge is defined.");
 });
 
-QUnit.test("Create mqtt_bridge", function(assert) {
-    let bridge = cotonic.mqtt_bridge.newBridge("");
+QUnit.test("Create default mqtt_bridge", function(assert) {
+    // This test sets up a websocket connection to localhost which is not used.
+    const mqtt_bridge = cotonic.mqtt_bridge;
 
+    let bridge = mqtt_bridge.newBridge();
     assert.equal(!!bridge, true, "Check if bridge is created");
+
+    let found = mqtt_bridge.findBridge();
+    assert.equal(!!found, true, "Check if bridge is found");
+
+    // Cleanup after the test
+    mqtt_bridge.deleteBridge();
+    assert.equal(mqtt_bridge.findBridge(), undefined, "Check if the bridge is deleted");
 });

--- a/test/cotonic.mqtt_bridge.test.js
+++ b/test/cotonic.mqtt_bridge.test.js
@@ -28,7 +28,7 @@ QUnit.test("Connect with mock mqtt_bridge", function(assert) {
     let done = assert.async();
 
     // Clear retained bridge status messages 
-    cotonic.broker.publish("$bridge/mock/status", undefined, {retained: true});
+    cotonic.broker.publish("$bridge/mock/status", undefined, {retain: true});
 
     let mockSession;
 

--- a/test/cotonic.mqtt_bridge.test.js
+++ b/test/cotonic.mqtt_bridge.test.js
@@ -1,0 +1,9 @@
+//
+// Bridge Tests.
+//
+
+"use strict";
+
+QUnit.test("cotonic.mqtt_bridge is defined", function(assert) {
+    assert.equal(cotonic.hasOwnProperty('mqtt_bridge'), true, "mqtt_bridge not defined.");
+});

--- a/test/cotonic.mqtt_bridge.test.js
+++ b/test/cotonic.mqtt_bridge.test.js
@@ -5,5 +5,11 @@
 "use strict";
 
 QUnit.test("cotonic.mqtt_bridge is defined", function(assert) {
-    assert.equal(cotonic.hasOwnProperty('mqtt_bridge'), true, "mqtt_bridge not defined.");
+    assert.equal(cotonic.hasOwnProperty('mqtt_bridge'), true, "Check if mqtt_bridge is defined.");
+});
+
+QUnit.test("Create mqtt_bridge", function(assert) {
+    let bridge = cotonic.mqtt_bridge.newBridge("");
+
+    assert.equal(!!bridge, true, "Check if bridge is created");
 });

--- a/test/cotonic.mqtt_transport.test.js
+++ b/test/cotonic.mqtt_transport.test.js
@@ -1,0 +1,9 @@
+//
+// Transport Tests.
+//
+
+"use strict";
+
+QUnit.test("cotonic.mqtt_transport is defined", function(assert) {
+    assert.equal(cotonic.hasOwnProperty('mqtt_transport'), true, "mqtt_transport not defined in cotonic");
+});

--- a/test/cotonic.worker.test.js
+++ b/test/cotonic.worker.test.js
@@ -12,8 +12,8 @@ QUnit.test("Receive connect from worker", function(assert) {
     worker.postMessage(["init", {}]);
 
     worker.onmessage = function(e) {
-        var cmd = e.data.cmd;
-        assert.equal(cmd, "connect");
+        var type = e.data.type;
+        assert.equal(type, "connect");
 	worker.terminate();
         done();
     }
@@ -29,12 +29,11 @@ QUnit.test("Connect and connack worker", function(assert) {
     var connected = false;
 
     worker.onmessage = function(e) {
-        console.log("XXXX", e.data);
         if(!connected) {
-            var cmd = e.data.cmd;
-            assert.equal(cmd, "connect");
+            var type = e.data.type;
+            assert.equal(type, "connect");
             connected = true;
-            worker.postMessage({cmd: "connack"})
+            worker.postMessage({type: "connack"})
         } else {
             // The hello world worker sends a normal postMessage
             assert.equal(e.data, "Hello world!")
@@ -54,19 +53,19 @@ QUnit.test("Connect and subscribe worker", function(assert) {
     worker.postMessage(["init", {}]);
 
     worker.onmessage = function(e) {
-        var cmd = e.data.cmd;
+        var type = e.data.type;
 
         if(!connected) {
-            assert.equal(cmd, "connect");
+            assert.equal(type, "connect");
             connected = true;
-            worker.postMessage({cmd: "connack"})
+            worker.postMessage({type: "connack"})
             return;
         }
 
         if(!subscribed) {
-            assert.equal(cmd, "subscribe");
+            assert.equal(type, "subscribe");
             subscribed = true;
-            worker.postMessage({cmd: "suback", sub_id: e.data.id})
+            worker.postMessage({type: "suback", sub_id: e.data.id})
 	    worker.terminate();
             done();
         }
@@ -84,7 +83,7 @@ QUnit.test("Connect, subscribe and publish to worker", function(assert) {
     var subscribed = false;
 
     worker.onmessage = function(e) {
-        var cmd = e.data.cmd;
+        var type = e.data.type;
 
 	if(e.data == "Hello to you too") {
 	    worker.terminate();
@@ -92,18 +91,18 @@ QUnit.test("Connect, subscribe and publish to worker", function(assert) {
 	}
 
         if(!connected) {
-            assert.equal(cmd, "connect");
+            assert.equal(type, "connect");
             connected = true;
-            worker.postMessage({cmd: "connack"})
+            worker.postMessage({type: "connack"})
             return;
         }
 
         if(!subscribed) {
-            assert.equal(cmd, "subscribe");
+            assert.equal(type, "subscribe");
             subscribed = true;
 
-            worker.postMessage({cmd: "suback", sub_id: e.data.id});
-	    worker.postMessage({cmd: "publish", topic: "test/a/b", payload: "Hi"});
+            worker.postMessage({type: "suback", sub_id: e.data.id});
+	    worker.postMessage({type: "publish", topic: "test/a/b", payload: "Hi"});
 
 	    return;
         }

--- a/test/cotonic.worker.test.js
+++ b/test/cotonic.worker.test.js
@@ -14,7 +14,7 @@ QUnit.test("Receive connect from worker", function(assert) {
     worker.onmessage = function(e) {
         var type = e.data.type;
         assert.equal(type, "connect");
-	worker.terminate();
+        worker.terminate();
         done();
     }
 });
@@ -37,7 +37,7 @@ QUnit.test("Connect and connack worker", function(assert) {
         } else {
             // The hello world worker sends a normal postMessage
             assert.equal(e.data, "Hello world!")
-	    worker.terminate();
+            worker.terminate();
             done();
         }
     }
@@ -65,8 +65,8 @@ QUnit.test("Connect and subscribe worker", function(assert) {
         if(!subscribed) {
             assert.equal(type, "subscribe");
             subscribed = true;
-            worker.postMessage({type: "suback", sub_id: e.data.id})
-	    worker.terminate();
+            worker.postMessage({type: "suback", packet_id: e.data.packet_id, acks: [0]})
+            worker.terminate();
             done();
         }
     }
@@ -85,10 +85,10 @@ QUnit.test("Connect, subscribe and publish to worker", function(assert) {
     worker.onmessage = function(e) {
         var type = e.data.type;
 
-	if(e.data == "Hello to you too") {
-	    worker.terminate();
-	    done();
-	}
+        if(e.data == "Hello to you too") {
+            worker.terminate();
+            done();
+        }
 
         if(!connected) {
             assert.equal(type, "connect");
@@ -101,10 +101,10 @@ QUnit.test("Connect, subscribe and publish to worker", function(assert) {
             assert.equal(type, "subscribe");
             subscribed = true;
 
-            worker.postMessage({type: "suback", sub_id: e.data.id});
-	    worker.postMessage({type: "publish", topic: "test/a/b", payload: "Hi"});
+            worker.postMessage({type: "suback", packet_id: e.data.packet_id, acks: [0]});
+            worker.postMessage({type: "publish", topic: "test/a/b", payload: "Hi"});
 
-	    return;
+            return;
         }
     }
 });

--- a/test/subscribe-publish-worker.js
+++ b/test/subscribe-publish-worker.js
@@ -8,7 +8,7 @@ importScripts("../src/cotonic.mqtt.js", "../src/cotonic.worker.js");
 
 self.on_connect = function() {
     self.subscribe("test/+a/b", function(msg, params) {
-	self.postMessage("Hello to you too");
+        self.postMessage("Hello to you too");
     })
 }
 

--- a/test/subscribe-unsubscribe-worker.js
+++ b/test/subscribe-unsubscribe-worker.js
@@ -1,5 +1,5 @@
 /**
- * Test worker which connects, and subscribes, and does nothing else.
+ * Test worker which connects, subscribes, and unsubscribes.
  */
 
 "use strict";
@@ -30,4 +30,4 @@ self.on_connect = function() {
     self.subscribe("test/check", onpubcheck);
 }
 
-self.connect("subscribe-worker");
+self.connect("subscribe-unsubscribe-worker");

--- a/test/subscribe-unsubscribe-worker.js
+++ b/test/subscribe-unsubscribe-worker.js
@@ -1,0 +1,33 @@
+/**
+ * Test worker which connects, and subscribes, and does nothing else.
+ */
+
+"use strict";
+
+importScripts("../src/cotonic.mqtt.js", "../src/cotonic.worker.js");
+
+self.on_connect = function() {
+    var pubct = -100;
+
+    function onpubcheck(msg, params) {
+        self.postMessage(pubct);
+    }
+
+    function unsuback(msg, params) {
+        pubct = 0;
+    }
+
+    function onpub(msg, params) {
+        if (pubct == -100) {
+            self.unsubscribe("test/a/b", unsuback);
+            pubct = 1;
+        } else {
+            pubct++;
+        }
+    }
+
+    self.subscribe("test/a/b", onpub);
+    self.subscribe("test/check", onpubcheck);
+}
+
+self.connect("subscribe-worker");


### PR DESCRIPTION
This adds the bridge between the topic tree on the server and the client's topic tree.

Things that will be changed:

 - [x] Change packet format of the broker to fit with the MQTT packets (`cmd` vs `type`, `msg` vs `payload` etc.)
 - [x] Export *match* function from the broker - the bridge needs to know about subscriptions after a session restart
 - [x] Add a *subscribe-hook* to the broker - the bridge needs to be informed about subscriptions to `bridge/#` topics
 - [ ] retain handling of bridge topics
 - [ ] retain flags on published messages, should conform to subscription retain_as_published
 - [ ] only allow server to client publish on public and reply topics (pending identity checks on signed publish packets)
