### PR TITLE
Publish to model/ui/event/:id when a element is updated

### DIFF
--- a/cotonic.js
+++ b/cotonic.js
@@ -1506,10 +1506,10 @@ var cotonic = cotonic || {};
 
         if(elt === null)  {
             /* It is not here, maybe it is the next time around */
-            return;
+            return false;
         }
 
-        renderElement(elt, id);
+        return renderElement(elt, id);
     }
 
     function renderElement(elt, id) {
@@ -1527,12 +1527,23 @@ var cotonic = cotonic || {};
             cotonic.idom.patchOuter(elt, s.data);
         }
         s.dirty = false;
+        return true;
     }
 
     function render() {
+        let updated_ids = [];
+
         for(let i = 0; i < order.length; i++) {
-            renderId(order[i].id);
+            if (renderId(order[i].id)) {
+                updated_ids.push(order[i].id);
+            }
         }
+        setTimeout(
+            function() {
+                for(let i = 0; i < updated_ids.length; i++) {
+                    cotonic.broker.publish("model/ui/event/dom-updated/" + updated_ids[i], { id: updated_ids[i] });
+                }
+            }, 0);
         dirty = false;
     }
 

--- a/examples/chat/index.html
+++ b/examples/chat/index.html
@@ -102,20 +102,11 @@
         });
 
         /**
-         * Scroll the bubble container to the bottom
-         */
-        const bubble_container = document.getElementById("bubble-container");
-        function scrollToBottom() {
-            bubble_container.scrollTop = bubble_container.scrollHeight
-        }
-
-        /**
          * Update the view. Publishes the updated bubble view, and scrolls
          * it to the bottom.
          */
         function updateView() {
             cotonic.broker.publish("model/ui/update/bubble-container", view());
-            setTimeout(scrollToBottom, 20);  // Wait a little bit before scrolling
         }
 
         /**
@@ -126,6 +117,15 @@
             messages.push({user_id: "$sys", msg: msg});
             updateView();
         }
+
+        /**
+         * Scroll the messages to the bottom when the view is updated. 
+         */
+        cotonic.broker.subscribe("model/ui/event/dom-updated/bubble-container",
+            function(m) {
+                const c = document.getElementById("bubble-container");
+                c.scrollTop = c.scrollHeight
+            });
 
         /**
          * Subscribe to the local topic "chat/nick", When the user 

--- a/index.html
+++ b/index.html
@@ -272,6 +272,7 @@ pre {
                     <li> - <a href="#model.ui.update.key">update/+key</a>
                     <li> - <a href="#model.ui.delete.key">delete/+key</a>
                     <li> - <a href="#model.ui.event.recent-activity">event/recent-activity</a>
+                    <li> - <a href="#model.ui.event.dom-updated">event/dom-updated/+key</a>
                     <li> - <a href="#model.ui.event.ui-status">event/ui-status</a>
                 </ul>
 
@@ -1389,6 +1390,14 @@ cotonic.broker.subscribe("model/location/event/ping",
 
             <h3 id="model.ui">model/ui</h3>
 
+            <p>
+            The ui model can be used to update the dom by publishing messages on one of the
+            <tt>model/ui/#</tt> topics. Elements can be inserted, deleted and updated. When
+            elements in the dom-tree are updated, the a message
+            <tt>model/ui/event/dom-updated/+key</tt> is published. This can be used to
+            react to dom-changes when they happen.
+            </p>
+
             <p id="model.ui.insert.key">
             <strong class="header">insert/+key</strong>
             <br>
@@ -1459,14 +1468,34 @@ self.subscribe("model/ui/event/user-activity",
         const a = m.payload.is_active:"active":"not active";
         console.log("The user is: ", a);
     }
-) 
+); 
 => Displays the user's activity status.</pre>
+
+            <p id="model.ui.event.dom-updated">
+            <strong class="header">event/dom-updated/+key</strong>
+            <br>
+            When the dom-tree is updated a message will be published. The
+            message is fired after the dom-tree is updated.
+            </p>
+            <pre>
+cotonic.broker.subscribe("model/ui/event/dom-updated/message-container",
+    function(m) {
+        const c = document.getElementById("message-container");
+        c.scrollTop = c.scrollHeight
+    }
+);
+=> Scrolls the messages bubble container to the bottom.
+            </pre>
+
+
 
             <p id="model.ui.event.ui-status">
             <strong class="header">event/ui-status</strong>
             <br>
             </p>
             <pre></pre>
+
+
 
             <!-- serviceWorker model -->
             <h3 id="model.serviceWorker">model/serviceWorker</h3>

--- a/src/cotonic.ui.js
+++ b/src/cotonic.ui.js
@@ -112,10 +112,10 @@ var cotonic = cotonic || {};
 
         if(elt === null)  {
             /* It is not here, maybe it is the next time around */
-            return;
+            return false;
         }
 
-        renderElement(elt, id);
+        return renderElement(elt, id);
     }
 
     function renderElement(elt, id) {
@@ -133,12 +133,23 @@ var cotonic = cotonic || {};
             cotonic.idom.patchOuter(elt, s.data);
         }
         s.dirty = false;
+        return true;
     }
 
     function render() {
+        let updated_ids = [];
+
         for(let i = 0; i < order.length; i++) {
-            renderId(order[i].id);
+            if (renderId(order[i].id)) {
+                updated_ids.push(order[i].id);
+            }
         }
+        setTimeout(
+            function() {
+                for(let i = 0; i < updated_ids.length; i++) {
+                    cotonic.broker.publish("model/ui/event/dom-updated/" + updated_ids[i], { id: updated_ids[i] });
+                }
+            }, 0);
         dirty = false;
     }
 


### PR DESCRIPTION
Issue https://github.com/zotonic/zotonic/issues/2362

This changes the ui manager to publish to the topic `model/ui/event/:id` whenever an element with the given id is updated during an animationFrame.

The publish is done with a timeout to not bock the main thread and have the DOM ready when the subscribers are called.
