### PR TITLE
Configure cotonic via a js api.

### DIFF
--- a/cotonic.js
+++ b/cotonic.js
@@ -5896,6 +5896,9 @@ var cotonic = cotonic || {};
 var cotonic = cotonic || {};
 
 (function(cotonic) {
+    cotonic.load_config_defaults(
+        {start_service_worker: true,
+         service_worker_src: "/cotonic-service-worker.js"});
 
     if (cotonic.config.start_service_worker && navigator.serviceWorker) {
         navigator.serviceWorker

--- a/cotonic.js
+++ b/cotonic.js
@@ -70,18 +70,24 @@ var cotonic = cotonic || {};
 cotonic.VERSION = "1.0.3";
 
 (function(cotonic) {
+    cotonic.config = cotonic.config || {};
+
+
     /* Get the data-base-worker-src from the script tag that loads
      * cotonic on this page.
      */
-    let BASE_WORKER_SRC = (function() {
+    (function() {
         const currentScript = document.currentScript || (function() {
             const scripts = document.getElementsByTagName("script");
             return scripts[scripts.length - 1];
         })();
+
         if(currentScript && currentScript.getAttribute("data-base-worker-src")) {
-            return currentScript.getAttribute("data-base-worker-src");
+            load_config_defaults({base_worker_src:
+                currentScript.getAttribute("data-base-worker-src")});
         } else {
-            return "/lib/cotonic/cotonic-worker-bundle.js?v=1";
+            load_config_defaults({base_worker_src:
+                "/lib/cotonic/cotonic-worker-bundle.js?v=1"})
         }
     })();
 
@@ -90,10 +96,15 @@ cotonic.VERSION = "1.0.3";
     let receive_handler = null;
 
     /**
-     * Set the base worker src url programatically
+     * Load config defaults into the cotonic.config object. Modules
+     * can call this function to add their default config settings
      */
-    function set_worker_base_src(url) {
-        BASE_WORKER_SRC = url;
+    function load_config_defaults(options) {
+        for(let key in options) {
+            if(!cotonic.config.hasOwnProperty(key)) {
+                cotonic.config[key] = options[key];
+            }
+        }
     }
 
     /**
@@ -121,11 +132,11 @@ cotonic.VERSION = "1.0.3";
      * Start a worker
      */
     function spawn(url, args) {
-        if(!BASE_WORKER_SRC){
+        if(!cotonic.config.base_worker_src){
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
 
-        return spawn_named("", url, BASE_WORKER_SRC, args);
+        return spawn_named("", url, cotonic.config.base_worker_src, args);
     }
 
     /**
@@ -135,7 +146,7 @@ cotonic.VERSION = "1.0.3";
     function spawn_named(name, url, base, args) {
         // TODO: check if the name of the worker is unique (or empty).
         // Return the existing worker_id if already running.
-        base = base || BASE_WORKER_SRC;
+        base = base || cotonic.config.base_worker_src;
         if(!base) {
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
@@ -245,7 +256,7 @@ cotonic.VERSION = "1.0.3";
 
     cleanupSessionStorage();
 
-    cotonic.set_worker_base_src = set_worker_base_src;
+    cotonic.load_config_defaults = load_config_defaults;
 
     cotonic.spawn = spawn;
     cotonic.spawn_named = spawn_named;
@@ -5886,9 +5897,9 @@ var cotonic = cotonic || {};
 
 (function(cotonic) {
 
-    if (navigator.serviceWorker) {
+    if (cotonic.config.start_service_worker && navigator.serviceWorker) {
         navigator.serviceWorker
-            .register('/cotonic-service-worker.js')
+            .register(cotonic.config.service_worker_src)
             .catch(
                 function(error) {
                     switch (error.name) {

--- a/index.html
+++ b/index.html
@@ -283,6 +283,7 @@ pre {
                     <li> - <a href="#model.serviceWorker.post.broadcast.channel">post/broadcast/+channel</a>
                     <li> - <a href="#model.serviceWorker.event.broadcast.channel">event/broadcast/+channel</a>
                     <li> - <a href="#model.serviceWorker.event.ping">event/ping</a>
+                    <li> - <a href="#model.serviceWorker.config"><em>Configuration</em></a>
                 </ul>
 
                 <a class="toc_title" href="#model.localStorage">
@@ -489,20 +490,26 @@ cotonic.receive(function(message, worker_id) {
     console.log("Received", message, "from worker", worker_id);
 });</pre>
             
-            <pre>
-&ltscript data-worker-base-src="/lib/cotonic-worker.js" src="/lib/cotonic.js"&gt;&lt;/script&gt;
-=> Cotonic will use '/lib/cotonic-worker.js' when new workers are spawned.</pre>
-
             <!-- configuration -->
             <p id="cotonic.config">
             <em class="header">Configuration</em>
             <br>
-
+            The page function has one configuration option. 
+            <dl>
+                <dt><tt>base_worker_src</tt></dt>
+                <dd>The url for the base worker runtime for cotonic. This runtime provides
+                    the required communication primitives.</dd>
+            </dl>
             </p>
             <pre>
+&ltscripts&gt;
+    window.cotonic = window.cotonic || {};
+    window.cotonic.config = {
+        base_worker_src: "/base/worker-bundle.js"
+    };
+&lt;/script&gt;
+&ltscripts src="cotonic.js"&gt;&lt;/script&gt;
 </pre>
-
-            
 
             <!-- Broker -->
 
@@ -1559,6 +1566,37 @@ cotonic.broker.subscribe("model/serviceWorker/event/ping",
         console.log("the serviceWorker model is enabled")
    });</pre>
 
+            <p id="model.serviceWorker.config">
+            <strong class="header"><em>Configuration</em></strong>
+            <br>
+            The service worker model has two configuration options.
+            <dl>
+                <dt><tt>start_service_worker</tt></dt>
+                <dd>When set to <tt>false</tt>, the service worker will not start.
+                    <br /><strong>default</strong> <tt>true</tt></dd>
+                <dt><tt>service_worker_src</tt></dt>
+                <dd>The url of the service worker which should be started.
+                    <br/ ><strong>default</strong>
+                    <tt>/cotonic-service-worker.js</tt></dd>
+            </dl>
+            
+            </p>
+
+            <pre>
+&ltscripts&gt;
+    window.cotonic = window.cotonic || {};
+    window.cotonic.config = {
+        start_service_worker: true,
+        service_worker_src: "/cotonic-service-worker.js"
+    };
+&lt;/script&gt;
+&ltscripts src="cotonic.js"&gt;&lt;/script&gt;
+
+</pre>
+
+
+            <!-- localStorage model -->
+
             <h3 id="model.localStorage">model/localStorage</h3>
 
             <p id="model.localStorage.get.key">
@@ -1573,6 +1611,7 @@ cotonic.broker.call("model/localStorage/get/a")
         console.log("a is set to:", m.payload)
     }
 );</pre>
+
 
             <p id="model.localStorage.post.key">
             <strong class="header">post/+key</strong>
@@ -1813,8 +1852,14 @@ cotonic.broker.subscribe("model/sessionStorage/event/+key",
         </section>
 
         <!-- Load cotonic to be able to play with it in the console -->
-        <script type="text/javascript" src="/cotonic.js"
-                data-base-worker-src="/cotonic-worker.js"></script>
+        <script>
+            window.cotonic = window.cotonic || {};
+            window.cotonic.config = {
+                start_service_worker: false,
+                base_worker_src: "/cotonic-worker.js"
+            }
+        </script>
+        <script type="text/javascript" src="/cotonic.js"></script>
         <script>
             console.log("Welcome to COTONIC. You can try the api in the console");
             console.log("------------------------------------------------------");

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ h1, h2, h3, h4, h5, h6 {
     padding-top: 20px;
 }
 
-strong.header {
+.header {
     color: #0778B0;
     font-weight: bolder;
     line-height: 200%;
@@ -154,7 +154,7 @@ pre {
                     <li> - <a href="#cotonic.exit">exit</a>
                     <li> - <a href="#cotonic.send">send</a>
                     <li> - <a href="#cotonic.receive">receive</a>
-                    <li> - <a href="#cotonic.set_worker_base_src">set_worker_base_src</a>
+                    <li> - <a href="#cotonic.config"><em>Configuration</em></a>
                 </ul>
 
                 <!-- Broker -->
@@ -489,26 +489,22 @@ cotonic.receive(function(message, worker_id) {
     console.log("Received", message, "from worker", worker_id);
 });</pre>
             
-            <!-- set_worker_base_src -->
-            <p id="cotonic.set_worker_base_src">
-            <strong class="header">set_worker_base_src</strong> <code>cotonic.set_worker_base_src(baseUrl)</code>
-            <br>
-            Set the base url to load additional importable cotonic modules from. This is used to locate the base
-            worker script which is needed to communicate with the other workers. It is usually located in the
-            same location as the main cotonic script.
-            <br>
-            By default the location is <tt>/lib/cotonic/cotonic-worker.js</tt>. It is also possible to 
-            configure this via the script via which cotonic itself is loaded on the page.
-            <em>Note: When this is not setup correctly, it will not be possible to spawn workers.</em>
-            </p>
-
-            <pre>
-cotonic.set_worker_base_src("/lib/js/cotonic-worker.js");
-=> Cotonic will now use the '/lib/js/cotonic-worker.js' when workers are spawned.</pre>
-
             <pre>
 &ltscript data-worker-base-src="/lib/cotonic-worker.js" src="/lib/cotonic.js"&gt;&lt;/script&gt;
 => Cotonic will use '/lib/cotonic-worker.js' when new workers are spawned.</pre>
+
+            <!-- configuration -->
+            <p id="cotonic.config">
+            <em class="header">Configuration</em>
+            <br>
+
+            </p>
+            <pre>
+</pre>
+
+            
+
+            <!-- Broker -->
 
             <h3 id="cotonic.broker">Broker</h3>
 

--- a/src/cotonic.js
+++ b/src/cotonic.js
@@ -22,18 +22,24 @@ var cotonic = cotonic || {};
 cotonic.VERSION = "1.0.3";
 
 (function(cotonic) {
+    cotonic.config = cotonic.config || {};
+
+
     /* Get the data-base-worker-src from the script tag that loads
      * cotonic on this page.
      */
-    let BASE_WORKER_SRC = (function() {
+    (function() {
         const currentScript = document.currentScript || (function() {
             const scripts = document.getElementsByTagName("script");
             return scripts[scripts.length - 1];
         })();
+
         if(currentScript && currentScript.getAttribute("data-base-worker-src")) {
-            return currentScript.getAttribute("data-base-worker-src");
+            load_config_defaults({base_worker_src:
+                currentScript.getAttribute("data-base-worker-src")});
         } else {
-            return "/lib/cotonic/cotonic-worker-bundle.js?v=1";
+            load_config_defaults({base_worker_src:
+                "/lib/cotonic/cotonic-worker-bundle.js?v=1"})
         }
     })();
 
@@ -42,10 +48,15 @@ cotonic.VERSION = "1.0.3";
     let receive_handler = null;
 
     /**
-     * Set the base worker src url programatically
+     * Load config defaults into the cotonic.config object. Modules
+     * can call this function to add their default config settings
      */
-    function set_worker_base_src(url) {
-        BASE_WORKER_SRC = url;
+    function load_config_defaults(options) {
+        for(let key in options) {
+            if(!cotonic.config.hasOwnProperty(key)) {
+                cotonic.config[key] = options[key];
+            }
+        }
     }
 
     /**
@@ -73,11 +84,11 @@ cotonic.VERSION = "1.0.3";
      * Start a worker
      */
     function spawn(url, args) {
-        if(!BASE_WORKER_SRC){
+        if(!cotonic.config.base_worker_src){
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
 
-        return spawn_named("", url, BASE_WORKER_SRC, args);
+        return spawn_named("", url, cotonic.config.base_worker_src, args);
     }
 
     /**
@@ -87,7 +98,7 @@ cotonic.VERSION = "1.0.3";
     function spawn_named(name, url, base, args) {
         // TODO: check if the name of the worker is unique (or empty).
         // Return the existing worker_id if already running.
-        base = base || BASE_WORKER_SRC;
+        base = base || cotonic.config.base_worker_src;
         if(!base) {
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
@@ -197,7 +208,7 @@ cotonic.VERSION = "1.0.3";
 
     cleanupSessionStorage();
 
-    cotonic.set_worker_base_src = set_worker_base_src;
+    cotonic.load_config_defaults = load_config_defaults;
 
     cotonic.spawn = spawn;
     cotonic.spawn_named = spawn_named;

--- a/src/cotonic.model.serviceWorker.js
+++ b/src/cotonic.model.serviceWorker.js
@@ -21,6 +21,9 @@
 var cotonic = cotonic || {};
 
 (function(cotonic) {
+    cotonic.load_config_defaults(
+        {start_service_worker: true,
+         service_worker_src: "/cotonic-service-worker.js"});
 
     if (cotonic.config.start_service_worker && navigator.serviceWorker) {
         navigator.serviceWorker

--- a/src/cotonic.model.serviceWorker.js
+++ b/src/cotonic.model.serviceWorker.js
@@ -22,9 +22,9 @@ var cotonic = cotonic || {};
 
 (function(cotonic) {
 
-    if (navigator.serviceWorker) {
+    if (cotonic.config.start_service_worker && navigator.serviceWorker) {
         navigator.serviceWorker
-            .register('/cotonic-service-worker.js')
+            .register(cotonic.config.service_worker_src)
             .catch(
                 function(error) {
                     switch (error.name) {


### PR DESCRIPTION
This PR makes it possible to configure the location of the base worker and service worker libraries via a javascript API. 

I chose to develop this as a JS api, because these configuration settings are mostly done by js programmers. Doing it this way also makes it possible to easily configure things in a CMS and possibly use built-in client side caching mechanisms.


Example zotonic config:

```django
<script>
   window.cotonic = window.cotonic || {};
   window.cotonic.config = {
       base_worker_src: "{% lib_url "js/worker-bundle.js" %}",
       service_worker_src: "{% lib_url "js/worker-bundle.js" %}"
   };
</script>
{% lib
      ...
      "js/cotonic-bundle.js"
      ...
%}
```