### PR TITLE
Startup improvements.

### DIFF
--- a/src/cotonic.event.js
+++ b/src/cotonic.event.js
@@ -18,6 +18,9 @@
 var cotonic = cotonic || {};
 
 (function(cotonic) {
+    // Resolve the cotonic.ready promise
+    cotonic.readyResolve();
+
     // Old fashioned way for IE as it can't handle: new Event('cotonic-ready');
     let event = document.createEvent('Event');
     event.initEvent('cotonic-ready', true, true);

--- a/src/cotonic.js
+++ b/src/cotonic.js
@@ -24,7 +24,6 @@ cotonic.VERSION = "1.0.4";
 (function(cotonic) {
     cotonic.config = cotonic.config || {};
 
-
     /* Get the data-base-worker-src from the script tag that loads
      * cotonic on this page.
      */
@@ -204,6 +203,10 @@ cotonic.VERSION = "1.0.4";
             result += characters.charAt(Math.floor(Math.random() * len));
         }
         return result;
+    }
+
+    if (!cotonic.ready) {
+        cotonic.ready = new Promise(function(resolve) { cotonic.readyResolve = resolve; });
     }
 
     cleanupSessionStorage();

--- a/src/cotonic.model.ui.js
+++ b/src/cotonic.model.ui.js
@@ -49,6 +49,13 @@ var cotonic = cotonic || {};
         setInterval(activity_publish, 10000);
 
         initTopicEvents(document);
+
+        if (cotonic.bufferedEvents) {
+            for (e in cotonic.bufferedEvents) {
+                topic_event(cotonic.bufferedEvents[e], true);
+            }
+            cotonic.bufferedEvents = [];
+        }
     }
 
     // Hook into topic-connected event handlers (submit, click, etc.)
@@ -71,28 +78,35 @@ var cotonic = cotonic || {};
 
     // Map form submit and element clicks to topics.
 
-    function topic_event( event ) {
+    function topic_event( event, isBuffered ) {
         const topic = event.target.getAttribute( "data-on"+event.type+"-topic" );
         let msg;
 
         if (typeof topic === "string") {
-            let cancel = event.target.getAttribute( "data-on"+event.type+"-cancel" );
+            let cancel = true;
 
-            if (cancel === null) {
-                cancel = true;
+            if (isBuffered) {
+                // Buffered events are already canceled
+                cancel = false;
             } else {
-                switch (cancel) {
-                    case "0":
-                    case "no":
-                    case "false":
-                        cancel = false;
-                        break;
-                    case "preventDefault":
-                        cancel = 'preventDefault';
-                        break;
-                    default:
-                        cancel = true;
-                        break;
+                let cancel = event.target.getAttribute( "data-on"+event.type+"-cancel" );
+
+                if (cancel === null) {
+                    cancel = true;
+                } else {
+                    switch (cancel) {
+                        case "0":
+                        case "no":
+                        case "false":
+                            cancel = false;
+                            break;
+                        case "preventDefault":
+                            cancel = 'preventDefault';
+                            break;
+                        default:
+                            cancel = true;
+                            break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Support for:
- `$promised/` topics, buffered till there is a subscriber
- pre-connected websocket
- buffered events
- `cotonic.ready.then(...)` promise (to be used instead of the `cotonic-ready` event)

Companion pull request: https://github.com/zotonic/zotonic/pull/2602