### PR TITLE
Add guard to start named workes only once.

### DIFF
--- a/cotonic-service-worker.js
+++ b/cotonic-service-worker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The Cotonic Authors. All Rights Reserved.
+ * Copyright 2016-2021 The Cotonic Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ self.addEventListener('activate', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
-    if (!event.request.headers.get('range')) {
+    if (   !event.request.headers.get('range')
+        && !event.request.headers.get('x-no-cache')) {
         // fetch drops the 'range' header, which is used
         // with video and audio requests.
         event.respondWith( fetch( event.request ) );

--- a/cotonic.js
+++ b/cotonic.js
@@ -47,7 +47,7 @@
 
 /* just a separator file */
 /**
- * Copyright 2018 The Cotonic Authors. All Rights Reserved.
+ * Copyright 2018-2021 The Cotonic Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ cotonic.VERSION = "1.0.4";
 
     let next_worker_id = 1;
     let workers = {};
+    let named_worker_ids = {};
     let receive_handler = null;
 
     /**
@@ -134,7 +135,6 @@ cotonic.VERSION = "1.0.4";
         if(!cotonic.config.base_worker_src){
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
-
         return spawn_named("", url, cotonic.config.base_worker_src, args);
     }
 
@@ -143,13 +143,14 @@ cotonic.VERSION = "1.0.4";
      * Use "" or 'undefined' for a nameless worker.
      */
     function spawn_named(name, url, base, args) {
-        // TODO: check if the name of the worker is unique (or empty).
         // Return the existing worker_id if already running.
+        if (name && named_worker_ids[name]) {
+            return named_worker_ids[name];
+        }
         base = base || cotonic.config.base_worker_src;
         if(!base) {
             throw("Can't spawn worker, no data-base-worker-src attribute set.");
         }
-
         const worker_id = next_worker_id++;
         const worker = new Worker(base);
 
@@ -174,7 +175,9 @@ cotonic.VERSION = "1.0.4";
         worker.onerror = error_from_worker.bind(this, worker_id);
 
         workers[worker_id] = worker;
-
+        if (name) {
+            named_worker_ids[name] = worker_id;
+        }
         return worker_id;
     }
 
@@ -212,8 +215,21 @@ cotonic.VERSION = "1.0.4";
         const worker = workers[wid];
         if(!worker) return;
 
+        if (worker.name) {
+            delete named_worker_ids[worker.name];
+        }
         worker.terminate();
         delete workers[wid];
+    }
+
+    /**
+     * Lookup the wid of a named worker
+     */
+    function whereis(name) {
+        if (name && named_worker_ids[name]) {
+            return named_worker_ids[name];
+        }
+        return undefined;
     }
 
     function receive(handler) {
@@ -263,6 +279,7 @@ cotonic.VERSION = "1.0.4";
 
     cotonic.spawn = spawn;
     cotonic.spawn_named = spawn_named;
+    cotonic.whereis = whereis;
     cotonic.exit = exit;
 
     cotonic.send = send;
@@ -4243,7 +4260,10 @@ var cotonic = cotonic || {};
                 cotonic.bridgeSocket = undefined;
             }
             if (!self.socket) {
-                self.socket = new WebSocket( self.remoteUrl, [ "mqtt.cotonic.org", "mqtt" ] );
+                // EMQ is erronously accepting any protocol starting with `mqtt`, so it accepts
+                // 'mqtt.cotonic.org', which starts the extra handshake.
+                // self.socket = new WebSocket( self.remoteUrl, [ "mqtt.cotonic.org", "mqtt" ] );
+                self.socket = new WebSocket( self.remoteUrl, [ "mqtt" ] );
             }
             self.socket.binaryType = 'arraybuffer';
             self.socket.onopen = onopen;

--- a/src/cotonic.service-worker.js
+++ b/src/cotonic.service-worker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The Cotonic Authors. All Rights Reserved.
+ * Copyright 2016-2021 The Cotonic Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ self.addEventListener('activate', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
-    if (!event.request.headers.get('range')) {
+    if (   !event.request.headers.get('range')
+        && !event.request.headers.get('x-no-cache')) {
         // fetch drops the 'range' header, which is used
         // with video and audio requests.
         event.respondWith( fetch( event.request ) );


### PR DESCRIPTION
Also add check for 'x-no-cache' header in the service worker to not use the fetch.
This is used by the fileuploader XMLHttpRequest.