### PR TITLE
Add model/sessionId, sync cotonic-sid over mqtt

### DIFF
--- a/src/cotonic.model.document.js
+++ b/src/cotonic.model.document.js
@@ -92,7 +92,7 @@ var cotonic = cotonic || {};
         var d = new Date();
         d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
         var expires = "expires="+d.toUTCString();
-        document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        document.cookie = cname + "=" + cvalue + "; " + expires + "; path=/; Secure; SameSite=None";
     }
 
     // TODO: handle case of fixed/guessed timezone

--- a/src/cotonic.model.sessionId.js
+++ b/src/cotonic.model.sessionId.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2021 The Cotonic Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+var cotonic = cotonic || {};
+
+(function(cotonic) {
+"use strict";
+
+    function s4() {
+        return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+    }
+
+    function setcookie(value) {
+        cotonic.broker.publish("model/document/post/cookie/cotonic-sid",
+                { value: value, exdays: 14 });
+    }
+
+    function generate() {
+        let value = s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+        window.localStorage.setItem("cotonic-sid", JSON.stringify(value));
+        cotonic.broker.publish("model/document/post/cookie/cotonic-sid",
+                { value: value, exdays: 4 });
+        cotonic.broker.publish("model/sessionId/event", value);
+        return value;
+    }
+
+    cotonic.broker.subscribe("model/sessionId/get", function(msg, bindings) {
+        if (msg.properties.response_topic) {
+            let value = window.localStorage.getItem("cotonic-sid");
+            if (typeof value == "string") {
+                try { value = JSON.parse(value); }
+                catch (e) {
+                    value = generate();
+                }
+            } else {
+                value = generate();
+            }
+            cotonic.broker.publish(msg.properties.response_topic, value);
+        }
+    });
+
+    cotonic.broker.subscribe("model/sessionId/post/reset", function(msg, bindings) {
+        let value = generate();
+        if (msg.properties.response_topic) {
+            cotonic.broker.publish(msg.properties.response_topic, value);
+        }
+    });
+
+    cotonic.broker.subscribe("model/sessionId/delete", function(msg, bindings) {
+        window.localStorage.removeItem("cotonic-sid");
+        if (msg.properties.response_topic) {
+            cotonic.broker.publish(msg.properties.response_topic, null);
+        }
+        cotonic.broker.publish("model/document/post/cookie/cotonic-sid",
+                { value: "", exdays: 0 });
+        cotonic.broker.publish("model/sessionId/event", null);
+    });
+
+    cotonic.broker.subscribe("model/localStorage/event/cotonic-sid", function(value) {
+        cotonic.broker.publish("model/sessionId/event", value);
+    });
+
+
+    function init() {
+        let value = window.localStorage.getItem("cotonic-sid");
+        if (typeof value == "string") {
+            try {
+                value = JSON.parse(value);
+                if (typeof value == "string" && value !== "") {
+                    setcookie(value);
+                } else {
+                    generate();
+                }
+            }
+            catch (e) {
+                value = generate();
+            }
+        } else {
+            value = generate();
+        }
+    }
+
+    init();
+
+    cotonic.broker.publish("model/sessionId/event/ping", "pong", { retain: true });
+
+}(cotonic));

--- a/src/cotonic.mqtt_session.js
+++ b/src/cotonic.mqtt_session.js
@@ -264,7 +264,6 @@ var cotonic = cotonic || {};
                     cotonic.broker
                         .call("model/sessionId/get")
                         .then(function(msg) {
-                            console.log("connect", msg.payload);
                             let connectMessage = {
                                 type: 'connect',
                                 client_id: self.clientId,

--- a/src/cotonic.mqtt_session.js
+++ b/src/cotonic.mqtt_session.js
@@ -109,6 +109,22 @@ var cotonic = cotonic || {};
                 }
             }
         });
+
+
+        /**
+         * Called if the cotonic-sid changes.
+         */
+        cotonic.broker.subscribe("model/sessionId/event", function(msg) {
+            if (typeof msg.payload == 'string') {
+                if (sessions['origin'] && sessions['origin'].isConnected()) {
+                    let data = {
+                        options: { sid: msg.payload }
+                    }
+                    let topic = 'bridge/origin/$client/' + sessions['origin'].clientId + "/sid";
+                    cotonic.broker.publish(topic, data, { qos: 0 });
+                }
+            }
+        });
     }
 
 
@@ -245,21 +261,27 @@ var cotonic = cotonic || {};
             // Connection established - try to send out 'connect'
             if (transportName == 'ws') {
                 if (isStateNew()) {
-                    let connectMessage = {
-                        type: 'connect',
-                        client_id: self.clientId,
-                        clean_start: self.cleanStart,
-                        keep_alive: MQTT_KEEP_ALIVE,
-                        username: self.authUserPassword.username,
-                        password: self.authUserPassword.password,
-                        properties: {
-                            session_expiry_interval: MQTT_SESSION_EXPIRY
-                        }
-                    };
-                    self.isSentConnect = self.sendMessage(connectMessage, true);
-                    if (self.isSentConnect) {
-                        self.isWaitConnack = true;
-                    }
+                    cotonic.broker
+                        .call("model/sessionId/get")
+                        .then(function(msg) {
+                            console.log("connect", msg.payload);
+                            let connectMessage = {
+                                type: 'connect',
+                                client_id: self.clientId,
+                                clean_start: self.cleanStart,
+                                keep_alive: MQTT_KEEP_ALIVE,
+                                username: self.authUserPassword.username,
+                                password: self.authUserPassword.password,
+                                properties: {
+                                    session_expiry_interval: MQTT_SESSION_EXPIRY,
+                                    cotonic_sid: msg.payload
+                                }
+                            };
+                            self.isSentConnect = self.sendMessage(connectMessage, true);
+                            if (self.isSentConnect) {
+                                self.isWaitConnack = true;
+                            }
+                        });
                 }
             }
         };


### PR DESCRIPTION
This is a replacement for the `sid` that was managed by Zotonic auth.

The Cotonic session id is managed by the `model/sessionId`, this stores the id in the localStorage and sets also a cookie with the session-id.  This cookie is for use with page reloads and other HTTP requests.

The MQTT connection syncs the new sessionId to the server side MQTT client process.