### PR TITLE
Add the online state to the lifecycle model.

### DIFF
--- a/examples/lifecycle/main.js
+++ b/examples/lifecycle/main.js
@@ -65,4 +65,3 @@ cotonic.broker.subscribe("model/lifecycle/event/state", function(m) {
     updateDisplayedState();
 })
 
-

--- a/index.html
+++ b/index.html
@@ -300,6 +300,7 @@ pre {
                 </a>
                 <ul class="toc_section">
                     <li> - <a href="#model.lifecycle.event.state">event/state</a>
+                    <li> - <a href="#model.lifecycle.event.online">event/online</a>
                     <li> - <a href="#model.lifecycle.event.ping">event/ping</a>
                 </ul>
 
@@ -1883,8 +1884,24 @@ self.subscribe("model/lifecycle/event/state",
         }
    });</pre>
 
-
-            </pre>
+            <p id="model.lifecycle.event.online">
+            <strong class="header">event/online</strong>
+            <br>
+            When the lifecycle model detects a change in the online state of the browser,
+            the state will be published on this topic. When the browser is online, <tt>true</tt>
+            will be published <tt>false</tt> otherwise.
+            </p>
+            <pre>
+self.subscribe("model/lifecycle/event/online",
+    function(m) {
+        if(m.payload) {
+            console.log("We are online");
+        } else {
+            console.log("We are offline");
+        }
+    }
+);
+</pre>
 
             <p id="model.lifecycle.event.ping">
             <strong class="header">event/ping</strong>

--- a/src/cotonic.mqtt_session.js
+++ b/src/cotonic.mqtt_session.js
@@ -514,6 +514,8 @@ var cotonic = cotonic || {};
                         return "text/x-integer";
                     }
                     return "text/x-number";
+                case "boolean":
+                    return "application/json";
                 case "object":
                     if (payload === null) {
                         return undefined;


### PR DESCRIPTION
When mobile browsers go to sleep, pages keep running, but the browser disconnects any running network connection. This means that the cotonic transport will be taken offline. The page will try to reconnect and a slower and slower rate. This PR removes the backoff counter when the browser goes to `active` state to allow quick reconnects.