### PR TITLE
Run dev server based on python version

### DIFF
--- a/devserver.py
+++ b/devserver.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python
 
 import sys
-import BaseHTTPServer
-import SimpleHTTPServer
+if sys.version_info.major < 3:
+    import BaseHTTPServer
+    import SimpleHTTPServer
+    baseServer = BaseHTTPServer
+    simpleServer = SimpleHTTPServer
+else:
+    import http.server
+    baseServer = http.server
+    simpleServer = http.server
 
-class NoCacheHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+class NoCacheHandler(simpleServer.SimpleHTTPRequestHandler):
     def end_headers(self):
         self.send_header("Cache-Control", "no-cache, no-store, must-revalidate, post-check=0, pre-check=0")
         self.send_header("Pragma", "no-cache")
         self.send_header("Expires", "0")
 
-        SimpleHTTPServer.SimpleHTTPRequestHandler.end_headers(self)
+        simpleServer.SimpleHTTPRequestHandler.end_headers(self)
 
 def serve(address):
-    httpd = BaseHTTPServer.HTTPServer(address, NoCacheHandler)
+    httpd = baseServer.HTTPServer(address, NoCacheHandler)
     sa = httpd.socket.getsockname()
     print("Serving HTTP on", sa[0], "port", sa[1], "...")
     httpd.serve_forever()

--- a/devserver.py
+++ b/devserver.py
@@ -15,7 +15,7 @@ class NoCacheHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 def serve(address):
     httpd = BaseHTTPServer.HTTPServer(address, NoCacheHandler)
     sa = httpd.socket.getsockname()
-    print "Serving HTTP on", sa[0], "port", sa[1], "..."
+    print("Serving HTTP on", sa[0], "port", sa[1], "...")
     httpd.serve_forever()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Those imports won't work in Python 3 which moved [`BaseHTTPServer`](https://python.readthedocs.io/en/v2.7.2/library/basehttpserver.html) and [`SimpleHTTPServer`](https://python.readthedocs.io/en/v2.7.2/library/simplehttpserver.html) to [`http.server`](
https://docs.python.org/3/library/http.server.html).
