### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@ pre {
             Place the <a href="https://cotonic.org/cotonic.js"><tt>cotonic.js</tt></a>,
             <a href="https://cotonic.org/cotonic-worker.js"><tt>cotonic-worker.js</tt></a> and
             <a href="https://cotonic.org/cotonic-service-worker.js"><tt>cotonic-service-worker.js</tt></a> scripts on a web-server.
-            (<em>Right-click and use "Save as"), or use one of the <a href="#changelog">download links</a></em>.
+            (<em>Right-click and use "Save link as..."), or use one of the <a href="#changelog">download links</a></em>.
 
             <br> <br>
             Add the following tag to the page:

--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@ pre {
             Place the <a href="https://cotonic.org/cotonic.js"><tt>cotonic.js</tt></a>,
             <a href="https://cotonic.org/cotonic-worker.js"><tt>cotonic-worker.js</tt></a> and
             <a href="https://cotonic.org/cotonic-service-worker.js"><tt>cotonic-service-worker.js</tt></a> scripts on a web-server.
-            (<em>Right-click and use "Safe as"), or use one of the <a href="#changelog">download links</a></em>.
+            (<em>Right-click and use "Save as"), or use one of the <a href="#changelog">download links</a></em>.
 
             <br> <br>
             Add the following tag to the page:


### PR DESCRIPTION
Fix typo and change `Save as` to `Save link as...` (both Chrome and Firefox use this label).