### PR TITLE
Added transport-connected and transport-disconnected events to the mqtt session.

### DIFF
--- a/cotonic.js
+++ b/cotonic.js
@@ -5055,7 +5055,7 @@ var cotonic = cotonic || {};
                 }
             }
 
-            publishEvent("transport-connected");
+            publishEvent("transport/connected");
         };
 
         function publish( pubmsg ) {
@@ -5215,7 +5215,7 @@ var cotonic = cotonic || {};
                 stopKeepAliveTimer();
             });
 
-            publishEvent("transport-disconnected");
+            publishEvent("transport/disconnected");
         };
 
         /**
@@ -5623,7 +5623,6 @@ var cotonic = cotonic || {};
             }
         }
 
-
         /**
          * Force all connections closed - happens on:
          * - receive of 'DISCONNECT'
@@ -5680,7 +5679,7 @@ var cotonic = cotonic || {};
         }
 
         /**
-         * Publish event
+         * Publish a session event
          */
         function publishEvent( event ) {
             localPublish(`${ self.bridgeTopics.session_event }/${ event }`, {});

--- a/cotonic.js
+++ b/cotonic.js
@@ -5054,6 +5054,8 @@ var cotonic = cotonic || {};
                         });
                 }
             }
+
+            publishEvent("transport-connected");
         };
 
         function publish( pubmsg ) {
@@ -5212,6 +5214,8 @@ var cotonic = cotonic || {};
                 self.keepAliveInterval = 0;
                 stopKeepAliveTimer();
             });
+
+            publishEvent("transport-disconnected");
         };
 
         /**
@@ -5676,6 +5680,13 @@ var cotonic = cotonic || {};
         }
 
         /**
+         * Publish event
+         */
+        function publishEvent( event ) {
+            localPublish(`${ self.bridgeTopics.session_event }/${ event }`, {});
+        }
+
+        /**
          * Initialize, connect to local topics
          */
         function init() {
@@ -5724,6 +5735,7 @@ var cotonic = cotonic || {};
     const SESSION_OUT_TOPIC = "session/+name/out";
     const SESSION_STATUS_TOPIC = "session/+name/status";
     const SESSION_CONTROL_TOPIC = "session/+name/control";
+    const SESSION_EVENT_TOPIC = "session/+name/event";
 
     // Bridges to remote servers and clients
     var bridges = {};
@@ -5801,7 +5813,8 @@ var cotonic = cotonic || {};
                 session_in: cotonic.mqtt.fill(SESSION_IN_TOPIC, {name: self.name}),
                 session_out: cotonic.mqtt.fill(SESSION_OUT_TOPIC, {name: self.name}),
                 session_status: cotonic.mqtt.fill(SESSION_STATUS_TOPIC, {name: self.name}),
-                session_control: cotonic.mqtt.fill(SESSION_CONTROL_TOPIC, {name: self.name})
+                session_control: cotonic.mqtt.fill(SESSION_CONTROL_TOPIC, {name: self.name}),
+                session_event: cotonic.mqtt.fill(SESSION_EVENT_TOPIC, {name: self.name})
             };
             cotonic.broker.subscribe(self.local_topics.bridge_local, relayOut, {wid: self.wid, no_local: true});
             cotonic.broker.subscribe(self.local_topics.bridge_control, bridgeControl);

--- a/src/cotonic.mqtt_bridge.js
+++ b/src/cotonic.mqtt_bridge.js
@@ -26,6 +26,7 @@ var cotonic = cotonic || {};
     const SESSION_OUT_TOPIC = "session/+name/out";
     const SESSION_STATUS_TOPIC = "session/+name/status";
     const SESSION_CONTROL_TOPIC = "session/+name/control";
+    const SESSION_EVENT_TOPIC = "session/+name/event";
 
     // Bridges to remote servers and clients
     var bridges = {};
@@ -103,7 +104,8 @@ var cotonic = cotonic || {};
                 session_in: cotonic.mqtt.fill(SESSION_IN_TOPIC, {name: self.name}),
                 session_out: cotonic.mqtt.fill(SESSION_OUT_TOPIC, {name: self.name}),
                 session_status: cotonic.mqtt.fill(SESSION_STATUS_TOPIC, {name: self.name}),
-                session_control: cotonic.mqtt.fill(SESSION_CONTROL_TOPIC, {name: self.name})
+                session_control: cotonic.mqtt.fill(SESSION_CONTROL_TOPIC, {name: self.name}),
+                session_event: cotonic.mqtt.fill(SESSION_EVENT_TOPIC, {name: self.name})
             };
             cotonic.broker.subscribe(self.local_topics.bridge_local, relayOut, {wid: self.wid, no_local: true});
             cotonic.broker.subscribe(self.local_topics.bridge_control, bridgeControl);

--- a/src/cotonic.mqtt_session.js
+++ b/src/cotonic.mqtt_session.js
@@ -283,6 +283,8 @@ var cotonic = cotonic || {};
                         });
                 }
             }
+
+            publishEvent("transport-connected");
         };
 
         function publish( pubmsg ) {
@@ -441,6 +443,8 @@ var cotonic = cotonic || {};
                 self.keepAliveInterval = 0;
                 stopKeepAliveTimer();
             });
+
+            publishEvent("transport-disconnected");
         };
 
         /**
@@ -902,6 +906,13 @@ var cotonic = cotonic || {};
                 self.bridgeTopics.session_status,
                 { is_connected: isConnected, client_id: self.clientId  },
                 { retain: true });
+        }
+
+        /**
+         * Publish event
+         */
+        function publishEvent( event ) {
+            localPublish(`${ self.bridgeTopics.session_event }/${ event }`, {});
         }
 
         /**

--- a/src/cotonic.mqtt_session.js
+++ b/src/cotonic.mqtt_session.js
@@ -284,7 +284,7 @@ var cotonic = cotonic || {};
                 }
             }
 
-            publishEvent("transport-connected");
+            publishEvent("transport/connected");
         };
 
         function publish( pubmsg ) {
@@ -444,7 +444,7 @@ var cotonic = cotonic || {};
                 stopKeepAliveTimer();
             });
 
-            publishEvent("transport-disconnected");
+            publishEvent("transport/disconnected");
         };
 
         /**
@@ -852,7 +852,6 @@ var cotonic = cotonic || {};
             }
         }
 
-
         /**
          * Force all connections closed - happens on:
          * - receive of 'DISCONNECT'
@@ -909,7 +908,7 @@ var cotonic = cotonic || {};
         }
 
         /**
-         * Publish event
+         * Publish a session event
          */
         function publishEvent( event ) {
             localPublish(`${ self.bridgeTopics.session_event }/${ event }`, {});


### PR DESCRIPTION
Added `transport-connected` and `transport-disconnected` events to an mqtt session object. This makes it possible to react to web socket and other transport disconnects.

See issue: #85 