### PR TITLE
Add on{event}Ignore to ui model

### DIFF
--- a/src/cotonic.model.ui.js
+++ b/src/cotonic.model.ui.js
@@ -146,6 +146,16 @@ function topic_event( event, isBuffered ) {
     if(!topicTarget)
         return;
 
+    const ignore = getFromDataset(event.target, topicTarget, `on${ event.type }Ignore`);
+    switch (ignore) {
+        case "1":
+        case "yes":
+        case "true":
+            return;
+        default:
+            break;
+    }
+
     const topic = topicTarget.dataset[topicName]
     let msg;
     let cancel = true;


### PR DESCRIPTION
This adds an extra data attribute to ignore an event for some event targets.

For example, ignoring the `oninput` on a text input makes it possible to have a form that will trigger a topic on any input except on typing in the text input.

Any element can have the`data-oninput-ignore="1"` (or other event) attribute. So it is possible to ignore an event for a group of elements.

