### PR TITLE
Skip duplicate unchecked checkboxes when serializing a form to a list

### DIFF
--- a/test/all.html
+++ b/test/all.html
@@ -14,6 +14,7 @@
                     "cotonic.tokenizer.html",
                     "cotonic.idom.html",
                     "cotonic.ui.html",
+                    "cotonic.ui-form.html",
                     "cotonic.event.html",
                     "cotonic.mqtt.html",
                     "cotonic.mqtt_packet.html",

--- a/test/cotonic.ui-form.html
+++ b/test/cotonic.ui-form.html
@@ -4,7 +4,6 @@
         <meta charset="utf-8">
         <link rel="stylesheet" href="/test/lib/qunit.css">
         <script src="/test/lib/qunit.js"></script>
-        <script type="text/javascript" src="/lib/incremental-dom.js"></script>
         <script type="module" src="cotonic.ui-form.test.js"></script>
     </head>
     <body>

--- a/test/cotonic.ui-form.html
+++ b/test/cotonic.ui-form.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="/test/lib/qunit.css">
+        <script src="/test/lib/qunit.js"></script>
+        <script type="text/javascript" src="/lib/incremental-dom.js"></script>
+        <script type="module" src="cotonic.ui-form.test.js"></script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+
+        <form id="form-a">
+
+            <input type="text" name="t1" value="">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2" checked>
+            <input type="checkbox" name="v[]" value="3" checked>
+            <input type="checkbox" name="v[]" value="4" checked>
+
+            <input type="text" name="t2" value="">
+
+            <input type="checkbox" name="v[]" value="1" checked>
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3">
+            <input type="checkbox" name="v[]" value="4">
+
+            <input type="text" name="t3" value="">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3">
+            <input type="checkbox" name="v[]" value="4">
+
+            <input type="text" name="t4" value="">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3">
+            <input type="checkbox" name="v[]" value="4">
+
+        </form>
+
+        <form id="form-b">
+
+            <input type="text" name="t1" value="">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2" checked>
+            <input type="checkbox" name="v[]" value="3" checked>
+            <input type="checkbox" name="v[]" value="4" checked>
+
+            <input type="text" name="t2" value="t2">
+
+            <input type="checkbox" name="v[]" value="1" checked>
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3">
+            <input type="checkbox" name="v[]" value="4">
+
+            <input type="text" name="t3" value="">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3">
+            <input type="checkbox" name="v[]" value="4">
+
+            <input type="text" name="t4" value="t4">
+
+            <input type="checkbox" name="v[]" value="1">
+            <input type="checkbox" name="v[]" value="2">
+            <input type="checkbox" name="v[]" value="3" checked>
+            <input type="checkbox" name="v[]" value="4">
+
+        </form>
+    </body>
+</html>

--- a/test/cotonic.ui-form.test.js
+++ b/test/cotonic.ui-form.test.js
@@ -1,0 +1,46 @@
+//
+// HTML Form serialize tests.
+//
+
+import "/src/default_broker_init.js";
+import * as ui from "/src/cotonic.ui.js";
+
+QUnit.test("Form serialize test", function(assert) {
+
+    let form = document.getElementById("form-a");
+    let s = ui.serializeFormToList(form);
+
+    assert.deepEqual([
+            [ "t1", "" ],
+            [ "v[]", "2" ],
+            [ "v[]", "3" ],
+            [ "v[]", "4" ],
+            [ "t2", "" ],
+            [ "v[]", "1" ],
+            [ "t3", "" ],
+            [ "v[]", "" ],
+            [ "t4", "" ],
+            [ "v[]", "" ]
+        ],
+        s);
+
+    form = document.getElementById("form-b");
+    s = ui.serializeFormToList(form);
+
+    assert.deepEqual([
+            [ "t1", "" ],
+            [ "v[]", "2" ],
+            [ "v[]", "3" ],
+            [ "v[]", "4" ],
+            [ "t2", "t2" ],
+            [ "v[]", "1" ],
+            [ "t3", "" ],
+            [ "v[]", "" ],
+            [ "t4", "t4" ],
+            [ "v[]", "3" ]
+        ],
+        s);
+
+    assert.ok(true);
+});
+

--- a/test/cotonic.ui-form.test.js
+++ b/test/cotonic.ui-form.test.js
@@ -2,6 +2,8 @@
 // HTML Form serialize tests.
 //
 
+import "/src-idom/index-bundle.js";
+
 import "/src/default_broker_init.js";
 import * as ui from "/src/cotonic.ui.js";
 

--- a/test/index.html
+++ b/test/index.html
@@ -23,6 +23,7 @@
                 <li> <a href="cotonic.tokenizer.html">HTML Tokenizer</a> </li>
                 <li> <a href="cotonic.idom.html">Interactive DOM integration</a> </li>
                 <li> <a href="cotonic.ui.html">UI Composer</a> </li>
+                <li> <a href="cotonic.ui-form.html">UI form serializer</a> </li>
                 <li> <a href="cotonic.event.html">Event</a> </li>
 
                 <li> <a href="cotonic.mqtt.html">MQTT Utilities</a> </li>


### PR DESCRIPTION
If you have a form with many (unchecked) checkboxes, then the serialization gets very long.

This removes the duplicate unchecked checkboxes if they are in sequence.