### PR TITLE
Fix an issue where Firefox does not send SameSite cookies on a reload

### DIFF
--- a/src/cotonic.model.location.js
+++ b/src/cotonic.model.location.js
@@ -154,7 +154,8 @@ subscribe("model/auth/event/auth-changing",
             if (onauth === null || onauth !== "#") {
                 setTimeout(function() {
                     if (onauth === null || onauth === '#reload') {
-                        window.location.reload(true);
+                        // Do not use reload(), as Firefox will not send SameSite cookies.
+                        window.location.replace(window.location.href);
                     } else if (onauth.charAt(0) == '/') {
                         window.location.href = onauth;
                     } else if (onauth.charAt(0) == '#') {
@@ -190,7 +191,7 @@ subscribe("model/location/post/push", function(msg) {
     let url = payload_url(msg);
     if (url) {
         url = new URL(url, window.location);
-        window.history.replaceState({}, '', url.pathname + url.search + url.hash);
+        window.history.pushState({}, '', url.pathname + url.search + url.hash);
         publishLocation();
     }
 }, {wid: "model.location"});
@@ -208,7 +209,7 @@ subscribe("model/location/post/push-silent", function(msg) {
     let url = payload_url(msg);
     if (url) {
         url = new URL(url, window.location);
-        window.history.replaceState({}, '', url.pathname + url.search + url.hash);
+        window.history.pushState({}, '', url.pathname + url.search + url.hash);
     }
 }, {wid: "model.location"});
 
@@ -257,7 +258,8 @@ function redirectLocal(url) {
 }
 
 subscribe("model/location/post/reload", function(msg) {
-    window.location.reload(true);
+    // Do not use reload(), as Firefox will not send SameSite cookies.
+    window.location.replace(window.location.href);
     willNavigate();
 }, {wid: "model.location"});
 


### PR DESCRIPTION
If we are navigating to a Zotonic site, then the SameSite authentication cookies are not sent along.
The auth worker will find out that the user is in fact logged in, and will request a reload.
On the reload the SameSite cookie should be passed to the server.
But, on Firefox the reload does _not_ send the SameSite cookies along.

https://github.com/httpwg/http-extensions/issues/628

This merge request changes the use of reload by modifying the document location, this let Firefox reload the page _with_ the SameSite cookies.

Also fix an issue where the location _push_ did in fact do a location _replace_.